### PR TITLE
Deprecate current bg color postprocessing in favor of more powerful background setup

### DIFF
--- a/kubric/viewer/blender.py
+++ b/kubric/viewer/blender.py
@@ -322,9 +322,6 @@ class Renderer(interface.Renderer):
     view_layer.cycles.use_pass_crypto_object = True  # segmentation
     view_layer.cycles.pass_crypto_depth = 2
 
-    # --- transparency
-    bpy.context.scene.render.film_transparent = True
-
     # --- compute devices
     # derek, why is the rationale? → rendering on GPU only sometime faster than CPU+GPU
     # TODO: modify the logic to execute on CPU, GPU, CPU+GPU
@@ -339,6 +336,9 @@ class Renderer(interface.Renderer):
     for dev in cyclePref.devices:
       print(dev)
       print(dev.use)
+
+  def set_background_transparent(self, film_transparent: bool):
+    bpy.context.scene.render.film_transparent = film_transparent
 
   def set_size(self, width: int, height: int):
     super().set_size(width, height)
@@ -495,8 +495,6 @@ class Renderer(interface.Renderer):
 
     # --- renders one frame directly to a png file
     elif path.endswith(".png"):
-      bpy.context.scene.render.film_transparent = True
-      self.postprocess_solidbackground(color=0xFF0000)
       # TODO: add capability bpy.context.scene.frame_set(frame_number)
       bpy.ops.render.render(write_still=True, animation=False)
 


### PR DESCRIPTION
The `set_up_background` method is now able to use an HDRI or a color for illumination, and can set the rendered background color too. The corresponding node setup is this:

<img width="1049" alt="Screenshot 2020-07-21 at 19 49 49" src="https://user-images.githubusercontent.com/1160920/88798141-baf9db80-d1a4-11ea-8be9-392753c56fe8.png">

Based on this tutorial: https://www.youtube.com/watch?v=dbAWTNCJVEs