### PR TITLE
changed simulator API to not expose internal object index

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+bidict
 mathutils
 trimesh
 google-cloud-storage

--- a/worker.py
+++ b/worker.py
@@ -58,7 +58,7 @@ placer = Placer(template=FLAGS.template, simulator=simulator)
 for urdf_path in urdf_paths:
   obj3d = Object3D(sim_filename=urdf_path)
   placer.place(obj3d)
-  simulator.place_object(obj3d)  # TODO: shoudn't this method be just "add" or "insert"?
+  simulator.add(obj3d)
 
 # TODO: Issue #4
 # blender → bpy.ops.import_scene.obj(filepath=path, axis_forward='Y', axis_up='Z')


### PR DESCRIPTION
Simulator now keeps an internal mapping from (external) `Object3D` instances to (internal) object indices.
