### PR TITLE
Major refactoring of the Kubric internals

### DIFF
--- a/kubric/assets/asset_source.py
+++ b/kubric/assets/asset_source.py
@@ -59,18 +59,18 @@ class AssetSource(object):
     logger.info('removing tmp dir: "%s"', self.local_temp_folder)
     self.local_temp_folder.cleanup()
 
-  def create(self, asset_id: str, spec: dict) -> FileBasedObject:
-    assert asset_id in self.db['id'].values, spec
+  def create(self, asset_id: str, **kwargs) -> FileBasedObject:
+    assert asset_id in self.db['id'].values, kwargs
     sim_filename, vis_filename, properties = self.fetch(asset_id)
 
     for pname in ['mass', 'friction', 'restitution', 'bounds']:
-      if pname in properties and pname not in spec:
-        spec[pname] = properties[pname]
+      if pname in properties and pname not in kwargs:
+        kwargs[pname] = properties[pname]
 
     return FileBasedObject(asset_id=asset_id,
                            simulation_filename=str(sim_filename),
                            render_filename=str(vis_filename),
-                           **spec)
+                           **kwargs)
 
   def fetch(self, object_id):
     object_path = self._download_file(object_id + '.tar.gz')

--- a/kubric/assets/asset_source.py
+++ b/kubric/assets/asset_source.py
@@ -38,32 +38,32 @@ class AssetSource(object):
     self.local_temp_folder = tempfile.TemporaryDirectory()
     self.local_path = pathlib.Path(self.local_temp_folder.name)
 
-    if sections.scheme == 'gs':   # cloud
-      self.protocol = 'gs'
+    if sections.scheme == "gs":   # cloud
+      self.protocol = "gs"
       self.bucket_name = sections.netloc
       self.path = sections.path
       self.client = storage.Client()
       self.bucket = self.client.get_bucket(self.bucket_name)
 
-    elif sections.scheme == '':  # local
-      self.protocol = 'local'
+    elif sections.scheme == "":  # local
+      self.protocol = "local"
       self.path = pathlib.Path(uri)
     else:
-      raise ValueError('Unknown protocol for {}'.format(uri))
+      raise ValueError("Unknown protocol for {}".format(uri))
 
     # TODO handle missing details list file
-    manifest = self._download_file('details_list.json')
+    manifest = self._download_file("details_list.json")
     self.db = pd.read_json(manifest)
 
   def __del__(self):
-    logger.info('removing tmp dir: "%s"', self.local_temp_folder)
+    logger.info("removing tmp dir: \"%s\"", self.local_temp_folder)
     self.local_temp_folder.cleanup()
 
   def create(self, asset_id: str, **kwargs) -> FileBasedObject:
-    assert asset_id in self.db['id'].values, kwargs
+    assert asset_id in self.db["id"].values, kwargs
     sim_filename, vis_filename, properties = self.fetch(asset_id)
 
-    for pname in ['mass', 'friction', 'restitution', 'bounds']:
+    for pname in ["mass", "friction", "restitution", "bounds"]:
       if pname in properties and pname not in kwargs:
         kwargs[pname] = properties[pname]
 
@@ -73,27 +73,27 @@ class AssetSource(object):
                            **kwargs)
 
   def fetch(self, object_id):
-    object_path = self._download_file(object_id + '.tar.gz')
+    object_path = self._download_file(object_id + ".tar.gz")
     with tarfile.open(object_path, "r:gz") as tar:
       tar.extractall(self.local_path)
 
-    urdf = self.local_path / object_id / 'object.urdf'
-    vis = self.local_path / object_id / 'visual_geometry.obj'
-    json_path = self.local_path / object_id / 'data.json'
+    urdf = self.local_path / object_id / "object.urdf"
+    vis = self.local_path / object_id / "visual_geometry.obj"
+    json_path = self.local_path / object_id / "data.json"
 
-    with open(json_path, 'r') as f:
+    with open(json_path, "r") as f:
       properties = json.load(f)
     return urdf, vis, properties
 
   def _download_file(self, filename):
     target_path = self.local_path / filename
-    if self.protocol == 'gs':
-      remote_path = f'gs://{self.bucket_name}{self.path}/{filename}'
+    if self.protocol == "gs":
+      remote_path = f"gs://{self.bucket_name}{self.path}/{filename}"
       logger.info("Downloading %s to %s", remote_path, str(target_path))
       blob = Blob.from_string(remote_path)
       blob.download_to_filename(str(target_path), client=self.client)
-    elif self.protocol == 'local':
-      remote_path = f'{self.path}/{filename}'
+    elif self.protocol == "local":
+      remote_path = f"{self.path}/{filename}"
       logger.info("Copying %s to %s", remote_path, str(target_path))
       shutil.copyfile(remote_path, target_path)
 

--- a/kubric/assets/klevr.py
+++ b/kubric/assets/klevr.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import numpy as np
-import colorsys
 
 from kubric.assets.asset_source import AssetSource
 from kubric.core import DirectionalLight, RectAreaLight, PerspectiveCamera, PrincipledBSDFMaterial
@@ -100,7 +99,7 @@ class KLEVR(AssetSource):
     rotation = self.get_random_rotation(rnd)
     spawn_region = np.array(self.spawn_region) - bounds
     position = rnd.uniform(*spawn_region)
-    return tuple(position), rotation
+    return position, rotation
 
   def get_random_object(self, rnd):
     random_id = rnd.choice(self.objects_list)
@@ -112,5 +111,5 @@ class KLEVR(AssetSource):
     return self.create(asset_id=random_id,
                        position=position,
                        quaternion=rotation,
-                       velocity=tuple(velocity),
+                       velocity=velocity,
                        material=material)

--- a/kubric/assets/klevr.py
+++ b/kubric/assets/klevr.py
@@ -1,0 +1,116 @@
+# Copyright 2020 The Kubric Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import colorsys
+
+from kubric.assets.asset_source import AssetSource
+from kubric.core import DirectionalLight, RectAreaLight, PerspectiveCamera, PrincipledBSDFMaterial
+from kubric.color import Color
+
+
+class KLEVR(AssetSource):
+  objects_list = [
+      "LargeMetalCube",
+      "LargeMetalCylinder",
+      "LargeMetalSphere",
+      "LargeRubberCube",
+      "LargeRubberCylinder",
+      "LargeRubberSphere",
+      "MetalSpot",
+      "RubberSpot",
+      "SmallMetalCube",
+      "SmallMetalCylinder",
+      "SmallMetalSphere",
+      "SmallRubberCube",
+      "SmallRubberCylinder",
+      "SmallRubberSphere",
+  ]
+
+  def __init__(self, uri: str):
+    super().__init__(uri)
+    self.spawn_region = ((-3.5, -3.5, 0), (3.5, 3.5, 2))
+    self.global_illumination = (0.05, 0.05, 0.05)
+
+  def get_scene_geometry(self):
+    return self.create(asset_id='Floor', static=True, position=(0, 0, -0.2))
+
+  def get_lights(self):
+    # --- Light settings from CLEVR
+    sun = DirectionalLight(color=Color.from_name('white'), intensity=0.45, shadow_softness=0.2,
+                           position=(11.6608, -6.62799, 25.8232))
+    sun.look_at((0, 0, 0))
+    lamp_back = RectAreaLight(color=Color.from_name('white'), intensity=50.,
+                              position=(-1.1685, 2.64602, 5.81574))
+    lamp_back.look_at((0, 0, 0))
+    lamp_key = RectAreaLight(color=Color.from_hexint(0xffedd0), intensity=100,
+                             width=0.5, height=0.5, position=(6.44671, -2.90517, 4.2584))
+    lamp_key.look_at((0, 0, 0))
+    lamp_fill = RectAreaLight(color=Color.from_hexint(0xc2d0ff), intensity=30,
+                              width=0.5, height=0.5, position=(-4.67112, -4.0136, 3.01122))
+    lamp_fill.look_at((0, 0, 0))
+    return [sun, lamp_back, lamp_key, lamp_fill]
+
+  def get_camera(self):
+    camera = PerspectiveCamera(focal_length=35., sensor_width=32,
+                               position=(7.48113, -6.50764, 5.34367))
+    camera.look_at((0, 0, 0))
+    return camera
+
+  def get_scene(self):
+    geometry = self.get_scene_geometry()
+    lights = self.get_lights()
+    camera = self.get_camera()
+    return geometry, lights, camera
+
+  def create_material(self, name, color_rgb):
+    if name == 'metal':
+      return PrincipledBSDFMaterial(
+          color=color_rgb,
+          roughness=0.2,
+          metallic=1.0,
+          ior=2.5)
+    elif name == 'rubber':
+      return PrincipledBSDFMaterial(
+          color=color_rgb,
+          roughness=0.7,
+          specular=0.33,
+          metallic=0.,
+          ior=1.25)
+
+  def get_random_rotation(self, rnd):
+    """Samples a random rotation around z axis (uniformly distributed)."""
+    theta = rnd.uniform(0, 2*np.pi)
+    return np.cos(theta), 0, 0, np.sin(theta)
+
+  def get_random_object_pose(self, asset_id, rnd):
+    properties = self.db[self.db['id'] == asset_id].iloc[0]   # there has to be a better way!
+    bounds = np.array(properties.get('bounds', [[0, 0, 0], [0, 0, 0]]))
+    rotation = self.get_random_rotation(rnd)
+    spawn_region = np.array(self.spawn_region) - bounds
+    position = rnd.uniform(*spawn_region)
+    return tuple(position), rotation
+
+  def get_random_object(self, rnd):
+    random_id = rnd.choice(self.objects_list)
+    position, rotation = self.get_random_object_pose(random_id, rnd)
+    velocity = rnd.uniform((-4, -4, 0), (4, 4, 0)) - [position[0], position[1], 0]  # bias towards center
+    color = Color.from_hsv(rnd.random_sample(), .95, 1.0)
+    material_type = 'metal' if 'Metal' in random_id else 'rubber'
+    material = self.create_material(material_type, color)
+    return self.create(asset_id=random_id,
+                       position=position,
+                       quaternion=rotation,
+                       velocity=tuple(velocity),
+                       material=material)

--- a/kubric/color.py
+++ b/kubric/color.py
@@ -1,0 +1,120 @@
+# Copyright 2020 The Kubric Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import colorsys
+from typing import NamedTuple
+
+
+class Color(NamedTuple):
+  """Represents a color in terms of float values for RGBA between 0.0 and 1.0."""
+
+  r: float
+  g: float
+  b: float
+  a: float = 1.
+
+  @property
+  def rgb(self):
+    return self.r, self.g, self.b
+
+  @property
+  def hsv(self):
+    return colorsys.rgb_to_hsv(self.r, self.g, self.b)
+
+  @property
+  def hexstr(self):
+    r, g, b, a = [int(x * 255) for x in self]
+    return f"#{r:02x}{g:02x}{b:02x}{a:02x}"
+
+  @property
+  def hexstr_short(self):
+    r, g, b, a = [int(x * 15) for x in self]
+    return f"#{r:01x}{g:01x}{b:01x}{a:01x}"
+
+  @classmethod
+  def from_hsv(cls, h: float, s: float, v: float, alpha=1.0):
+    if not 0 <= h <= 1:
+      raise ValueError('Hue has to be between 0.0 and 1.0 (was {})'.format(h))
+    if not 0 <= s <= 1:
+      raise ValueError('Saturation has to be between 0.0 and 1.0 (was {})'.format(s))
+    if not 0 <= v <= 1:
+      raise ValueError('Value has to be between 0.0 and 1.0 (was {})'.format(v))
+    return cls(*colorsys.hsv_to_rgb(h, s, v), a=alpha)
+
+  @classmethod
+  def from_hexint(cls, hexint: int, alpha: float = 1.0):
+    """Create a Color instance from a hex integer like 0xaaff33 and an optional alpha value."""
+    if not 0 <= hexint <= 0xffffff:
+      raise ValueError("hexint has to be between 0x000000 and 0xffffff (was 0x{:06x})".format(hexint))
+    if not 0. <= alpha <= 1.0:
+      raise ValueError("alpha has to be between 0.0 and 1.0 (was {})".format(alpha))
+    b = hexint & 255
+    g = (hexint >> 8) & 255
+    r = (hexint >> 16) & 255
+    return cls(r / 255.0, g / 255.0, b / 255.0, alpha)
+
+  @classmethod
+  def from_hexstr(cls, hexstr: str):
+    """Create a Color instance from a hex string like #ffaa22 or #11aa88ff.
+
+    Supports both long and short form (i.e. #ffffff is the same as #fff), and also an optional
+    alpha value (e.g. #112233ff or #123f).
+    """
+    if hexstr[0] == '#':  # get rid of leading #
+      hexstr = hexstr[1:]
+    if len(hexstr) == 3:
+      r = int(hexstr[0], 16) / 15.
+      g = int(hexstr[1], 16) / 15.
+      b = int(hexstr[2], 16) / 15.
+      return cls(r, g, b)
+    elif len(hexstr) == 4:
+      r = int(hexstr[0], 16) / 15.
+      g = int(hexstr[1], 16) / 15.
+      b = int(hexstr[2], 16) / 15.
+      a = int(hexstr[3], 16) / 15.
+      return cls(r, g, b, a)
+    elif len(hexstr) == 6:
+      r = int(hexstr[0:2], 16) / 255.0
+      g = int(hexstr[2:4], 16) / 255.0
+      b = int(hexstr[4:6], 16) / 255.0
+      return cls(r, g, b)
+    elif len(hexstr) == 8:
+      r = int(hexstr[0:2], 16) / 255.0
+      g = int(hexstr[2:4], 16) / 255.0
+      b = int(hexstr[4:6], 16) / 255.0
+      a = int(hexstr[6:8], 16) / 255.0
+      return cls(r, g, b, a)
+    else:
+      raise ValueError("invalid color hex string")
+
+  @classmethod
+  def from_name(cls, name: str):
+    return {
+        "aqua":    cls.from_hexstr("#00ffff"),
+        "black":   cls.from_hexstr("#000000"),
+        "blue":    cls.from_hexstr("#0000ff"),
+        "fuchsia": cls.from_hexstr("#ff00ff"),
+        "green":   cls.from_hexstr("#008000"),
+        "gray":    cls.from_hexstr("#808080"),
+        "lime":    cls.from_hexstr("#00ff00"),
+        "maroon":  cls.from_hexstr("#800000"),
+        "navy":    cls.from_hexstr("#000080"),
+        "olive":   cls.from_hexstr("#808000"),
+        "purple":  cls.from_hexstr("#800080"),
+        "red":     cls.from_hexstr("#ff0000"),
+        "silver":  cls.from_hexstr("#c0c0c0"),
+        "teal":    cls.from_hexstr("#008080"),
+        "white":   cls.from_hexstr("#ffffff"),
+        "yellow":  cls.from_hexstr("#ffff00"),
+    }[name.lower]

--- a/kubric/color.py
+++ b/kubric/color.py
@@ -117,4 +117,4 @@ class Color(NamedTuple):
         "teal":    cls.from_hexstr("#008080"),
         "white":   cls.from_hexstr("#ffffff"),
         "yellow":  cls.from_hexstr("#ffff00"),
-    }[name.lower]
+    }[name.lower()]

--- a/kubric/core.py
+++ b/kubric/core.py
@@ -67,6 +67,7 @@ class PrincipledBSDFMaterial(Material):
   roughness = tl.Float(0.4)
   ior = tl.Float(1.45)
   transmission = tl.Float(0)
+  transmission_roughness = tl.Float(0)
   emission = kt.RGBA(default_value=Color.from_name('black'))
 
 
@@ -94,7 +95,7 @@ class PhysicalObject(Object3D):
   static = tl.Bool(False)
   mass = tl.Float(1.0)
   friction = tl.Float(0.0)
-  restitution = tl.Float(1.0)
+  restitution = tl.Float(0.5)
 
   bounds = tl.Tuple(kt.Vector3D(), kt.Vector3D(),
                     default_value=((0., 0., 0.), (0., 0, 0.)))

--- a/kubric/core.py
+++ b/kubric/core.py
@@ -71,6 +71,10 @@ class PrincipledBSDFMaterial(Material):
   emission = kt.RGBA(default_value=Color.from_name('black'))
 
 
+class MeshChromeMaterial(Material):
+  color = kt.RGBA(default_value=Color.from_name('white'))
+  roughness = tl.Float(0.4)
+
 # ## ### ####  3D Objects  #### ### ## #
 
 

--- a/kubric/core.py
+++ b/kubric/core.py
@@ -88,8 +88,7 @@ class Object3D(Asset):
 
   def look_at(self, target):
     direction = mathutils.Vector(target) - mathutils.Vector(self.position)
-    mathutils.Quaternion
-    self.quaternion = tuple(direction.to_track_quat(self.front.upper(), self.up.upper()))
+    self.quaternion = direction.to_track_quat(self.front.upper(), self.up.upper())
 
 
 class PhysicalObject(Object3D):

--- a/kubric/core.py
+++ b/kubric/core.py
@@ -1,0 +1,208 @@
+# Copyright 2020 The Kubric Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import uuid
+from collections import defaultdict
+
+import traitlets as tl
+import mathutils
+from traitlets import default, validate
+
+import kubric.traits as kt
+from kubric.color import Color
+
+
+class Asset(tl.HasTraits):
+  uid = tl.Unicode(read_only=True)
+
+  def __init__(self, *args, **kwargs):
+    super().__init__(*args, **kwargs)
+    self.destruction_callbacks = []
+    self.keyframe_callbacks = []
+    self.keyframes = defaultdict(dict)
+
+  @default('uid')
+  def _uid(self):
+    return str(uuid.uuid4())
+
+  def keyframe_insert(self, member: str, frame: int):
+    if not self.has_trait(member):
+      raise KeyError('Unknown member "{}".'.format(member))
+    self.keyframes[member][frame] = getattr(self, member)
+    for func in self.keyframe_callbacks:
+      func(owner=self, member=member, frame=frame)
+
+  def __hash__(self):
+    return object.__hash__(self)
+
+  def __eq__(self, other):
+    return id(self) == id(other)
+
+  def __del__(self):
+    for func in self.destruction_callbacks:
+      func(owner=self)
+
+
+# ## ### ####  Materials  #### ### ## #
+
+class Material(Asset):
+  pass
+
+
+class PrincipledBSDFMaterial(Material):
+  color = kt.RGBA(default_value=Color.from_name('white'))
+  metallic = tl.Float(0.)
+  specular = tl.Float(0.5)
+  specular_tint = tl.Float(0.)
+  roughness = tl.Float(0.4)
+  ior = tl.Float(1.45)
+  transmission = tl.Float(0)
+  emission = kt.RGBA(default_value=Color.from_name('black'))
+
+
+# ## ### ####  3D Objects  #### ### ## #
+
+
+class Object3D(Asset):
+  position = kt.Vector3D(default_value=(0., 0., 0.))
+  quaternion = kt.Quaternion()
+  scale = kt.Vector3D(default_value=(1., 1., 1.))
+
+  up = tl.CaselessStrEnum(['X', 'Y', 'Z', '-X', '-Y', '-Z'], default_value='Y')
+  front = tl.CaselessStrEnum(['X', 'Y', 'Z', '-X', '-Y', '-Z'], default_value='-Z')
+
+  def look_at(self, target):
+    direction = mathutils.Vector(target) - mathutils.Vector(self.position)
+    mathutils.Quaternion
+    self.quaternion = tuple(direction.to_track_quat(self.front.upper(), self.up.upper()))
+
+
+class PhysicalObject(Object3D):
+  velocity = kt.Vector3D(default_value=(0., 0., 0.))
+  angular_velocity = kt.Vector3D(default_value=(0., 0., 0.))
+
+  static = tl.Bool(False)
+  mass = tl.Float(1.0)
+  friction = tl.Float(0.0)
+  restitution = tl.Float(1.0)
+
+  bounds = tl.Tuple(kt.Vector3D(), kt.Vector3D(),
+                    default_value=((0., 0., 0.), (0., 0, 0.)))
+
+  @validate('mass')
+  def _valid_mass(self, proposal):
+    mass = proposal['value']
+    if mass < 0:
+      raise tl.TraitError(f'mass cannot be negative ({mass})')
+    return mass
+
+  @validate('friction')
+  def _valid_friction(self, proposal):
+    friction = proposal['value']
+    if friction < 0:
+      raise tl.TraitError(f'friction cannot be negative ({friction})')
+    return friction
+
+  @validate('friction')
+  def _valid_friction(self, proposal):
+    friction = proposal['value']
+    if friction < 0:
+      raise tl.TraitError(f'friction cannot be negative ({friction})')
+    return friction
+
+  @validate('bounds')
+  def _valid_bounds(self, proposal):
+    lower, upper = proposal['value']
+    for l, u in zip(lower, upper):
+      if l > u:
+        raise tl.TraitError(f'lower bound cannot be larger than upper bound ({lower} !<= {upper})')
+    return lower, upper
+
+
+class FileBasedObject(PhysicalObject):
+  asset_id = tl.Unicode()
+
+  simulation_filename = tl.Unicode()   # TODO: use pathlib.Path instead
+  render_filename = tl.Unicode()       # TODO: use pathlib.Path instead
+
+  material = tl.Instance(Material, allow_none=True, default_value=None)
+
+
+# ## ### ####  Lights  #### ### ## #
+
+class Light(Object3D):
+  color = kt.RGB(default_value=Color.from_name('white').rgb)
+  intensity = tl.Float(1.)
+
+
+class DirectionalLight(Light):
+  shadow_softness = tl.Float(0.2)
+
+
+class RectAreaLight(Light):
+  width = tl.Float(1)
+  height = tl.Float(1)
+
+
+class PointLight(Light):
+  pass
+
+
+# ## ### ####  Cameras  #### ### ## #
+
+class Camera(Object3D):
+  pass
+
+
+class PerspectiveCamera(Camera):
+  focal_length = tl.Float(50)
+  sensor_width = tl.Float(36)
+
+
+class OrthographicCamera(Camera):
+  pass
+
+
+# ## ### ####  Scene  #### ### ## #
+
+class Scene(Asset):
+  frame_start = tl.Integer(0)
+  frame_end = tl.Integer(48)
+
+  frame_rate = tl.Integer(24)
+  step_rate = tl.Integer(240)
+
+  camera = tl.Instance(Camera, allow_none=True, default_value=None)
+  resolution = tl.Tuple(tl.Integer(), tl.Integer(), default_value=(512, 512))
+
+  gravity = kt.Vector3D(default_value=(0, 0, -10.))
+
+
+class AttributeSetter:
+  def __init__(self, target_obj, target_name):
+    self.target_name = target_name
+    self.target_obj = target_obj
+    self.mapping = None  # has to be set by the add() function
+
+  def __call__(self, change):
+    if isinstance(self.target_name, (list, tuple)):
+      for name, val in zip(self.target_name, change.new):
+        self._set(name, val)
+    else:
+      self._set(self.target_name, change.new)
+
+  def _set(self, name, value):
+    if isinstance(value, Asset):
+      value = self.mapping[value]  # convert kubric objects to blender objects before assigning
+    setattr(self.target_obj, name, value)
+

--- a/kubric/core.py
+++ b/kubric/core.py
@@ -18,7 +18,7 @@ import traitlets as tl
 import mathutils
 from traitlets import default, validate
 
-import kubric.traits as kt
+import kubric.traits as ktl
 from kubric.color import Color
 
 
@@ -31,13 +31,13 @@ class Asset(tl.HasTraits):
     self.keyframe_callbacks = []
     self.keyframes = defaultdict(dict)
 
-  @default('uid')
+  @default("uid")
   def _uid(self):
     return str(uuid.uuid4())
 
   def keyframe_insert(self, member: str, frame: int):
     if not self.has_trait(member):
-      raise KeyError('Unknown member "{}".'.format(member))
+      raise KeyError("Unknown member \"{}\".".format(member))
     self.keyframes[member][frame] = getattr(self, member)
     for func in self.keyframe_callbacks:
       func(owner=self, member=member, frame=frame)
@@ -60,7 +60,7 @@ class Material(Asset):
 
 
 class PrincipledBSDFMaterial(Material):
-  color = kt.RGBA(default_value=Color.from_name('white'))
+  color = ktl.RGBA(default_value=Color.from_name("white"))
   metallic = tl.Float(0.)
   specular = tl.Float(0.5)
   specular_tint = tl.Float(0.)
@@ -68,23 +68,23 @@ class PrincipledBSDFMaterial(Material):
   ior = tl.Float(1.45)
   transmission = tl.Float(0)
   transmission_roughness = tl.Float(0)
-  emission = kt.RGBA(default_value=Color.from_name('black'))
+  emission = ktl.RGBA(default_value=Color.from_name("black"))
 
 
 class MeshChromeMaterial(Material):
-  color = kt.RGBA(default_value=Color.from_name('white'))
+  color = ktl.RGBA(default_value=Color.from_name("white"))
   roughness = tl.Float(0.4)
 
 # ## ### ####  3D Objects  #### ### ## #
 
 
 class Object3D(Asset):
-  position = kt.Vector3D(default_value=(0., 0., 0.))
-  quaternion = kt.Quaternion()
-  scale = kt.Vector3D(default_value=(1., 1., 1.))
+  position = ktl.Vector3D(default_value=(0., 0., 0.))
+  quaternion = ktl.Quaternion(default_value=(1., 0., 0., 0.))
+  scale = ktl.Vector3D(default_value=(1., 1., 1.))
 
-  up = tl.CaselessStrEnum(['X', 'Y', 'Z', '-X', '-Y', '-Z'], default_value='Y')
-  front = tl.CaselessStrEnum(['X', 'Y', 'Z', '-X', '-Y', '-Z'], default_value='-Z')
+  up = tl.CaselessStrEnum(["X", "Y", "Z", "-X", "-Y", "-Z"], default_value="Y")
+  front = tl.CaselessStrEnum(["X", "Y", "Z", "-X", "-Y", "-Z"], default_value="-Z")
 
   def look_at(self, target):
     direction = mathutils.Vector(target) - mathutils.Vector(self.position)
@@ -92,44 +92,44 @@ class Object3D(Asset):
 
 
 class PhysicalObject(Object3D):
-  velocity = kt.Vector3D(default_value=(0., 0., 0.))
-  angular_velocity = kt.Vector3D(default_value=(0., 0., 0.))
+  velocity = ktl.Vector3D(default_value=(0., 0., 0.))
+  angular_velocity = ktl.Vector3D(default_value=(0., 0., 0.))
 
   static = tl.Bool(False)
   mass = tl.Float(1.0)
   friction = tl.Float(0.0)
   restitution = tl.Float(0.5)
 
-  bounds = tl.Tuple(kt.Vector3D(), kt.Vector3D(),
+  bounds = tl.Tuple(ktl.Vector3D(), ktl.Vector3D(),
                     default_value=((0., 0., 0.), (0., 0, 0.)))
 
-  @validate('mass')
+  @validate("mass")
   def _valid_mass(self, proposal):
-    mass = proposal['value']
+    mass = proposal["value"]
     if mass < 0:
-      raise tl.TraitError(f'mass cannot be negative ({mass})')
+      raise tl.TraitError(f"mass cannot be negative ({mass})")
     return mass
 
-  @validate('friction')
+  @validate("friction")
   def _valid_friction(self, proposal):
-    friction = proposal['value']
+    friction = proposal["value"]
     if friction < 0:
-      raise tl.TraitError(f'friction cannot be negative ({friction})')
+      raise tl.TraitError(f"friction cannot be negative ({friction})")
     return friction
 
-  @validate('friction')
+  @validate("friction")
   def _valid_friction(self, proposal):
-    friction = proposal['value']
+    friction = proposal["value"]
     if friction < 0:
-      raise tl.TraitError(f'friction cannot be negative ({friction})')
+      raise tl.TraitError(f"friction cannot be negative ({friction})")
     return friction
 
-  @validate('bounds')
+  @validate("bounds")
   def _valid_bounds(self, proposal):
-    lower, upper = proposal['value']
+    lower, upper = proposal["value"]
     for l, u in zip(lower, upper):
       if l > u:
-        raise tl.TraitError(f'lower bound cannot be larger than upper bound ({lower} !<= {upper})')
+        raise tl.TraitError(f"lower bound cannot be larger than upper bound ({lower} !<= {upper})")
     return lower, upper
 
 
@@ -145,7 +145,7 @@ class FileBasedObject(PhysicalObject):
 # ## ### ####  Lights  #### ### ## #
 
 class Light(Object3D):
-  color = kt.RGB(default_value=Color.from_name('white').rgb)
+  color = ktl.RGB(default_value=Color.from_name("white").rgb)
   intensity = tl.Float(1.)
 
 
@@ -189,7 +189,7 @@ class Scene(Asset):
   camera = tl.Instance(Camera, allow_none=True, default_value=None)
   resolution = tl.Tuple(tl.Integer(), tl.Integer(), default_value=(512, 512))
 
-  gravity = kt.Vector3D(default_value=(0, 0, -10.))
+  gravity = ktl.Vector3D(default_value=(0, 0, -10.))
 
 
 class AttributeSetter:

--- a/kubric/traits.py
+++ b/kubric/traits.py
@@ -31,7 +31,7 @@ class Vector3D(tl.TraitType):
 
 class Quaternion(tl.TraitType):
   default_value = (1, 0, 0, 0)
-  info_text = "a 4D vector (quaternion) of floats"
+  info_text = "a 4D vector (WXYZ quaternion) of floats"
 
   def _validate(self, obj, value):
     value = tuple([float(v) for v in value])
@@ -57,8 +57,6 @@ class RGBA(tl.TraitType):
     else:
       return self.error(obj, value)
 
-    if not len(color) == 4:
-      self.error(obj, value)
     if not all([0 <= x <= 1 for x in color]):
       self.error(obj, value)
 

--- a/kubric/traits.py
+++ b/kubric/traits.py
@@ -17,9 +17,28 @@ import traitlets as tl
 from kubric.color import Color
 
 
-# TODO: support numpy arrays
-Vector3D = lambda default_value=(0., 0., 0.): tl.Tuple(tl.Float(), tl.Float(), tl.Float(), default_value=default_value)
-Quaternion = lambda: tl.Tuple(tl.Float(), tl.Float(), tl.Float(), tl.Float(), default_value=(1.0, 0, 0, 0))
+class Vector3D(tl.TraitType):
+  default_value = (0, 0, 0)
+  info_text = "a 3D vector of floats"
+
+  def _validate(self, obj, value):
+    value = tuple([float(v) for v in value])
+    if len(value) != 3:
+      self.error(obj, value)
+    else:
+      return value
+
+
+class Quaternion(tl.TraitType):
+  default_value = (1, 0, 0, 0)
+  info_text = "a 4D vector (quaternion) of floats"
+
+  def _validate(self, obj, value):
+    value = tuple([float(v) for v in value])
+    if len(value) != 4:
+      self.error(obj, value)
+    else:
+      return value
 
 
 class RGBA(tl.TraitType):

--- a/kubric/traits.py
+++ b/kubric/traits.py
@@ -1,0 +1,72 @@
+# Copyright 2020 The Kubric Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import traitlets as tl
+
+from kubric.color import Color
+
+
+# TODO: support numpy arrays
+Vector3D = lambda default_value=(0., 0., 0.): tl.Tuple(tl.Float(), tl.Float(), tl.Float(), default_value=default_value)
+Quaternion = lambda: tl.Tuple(tl.Float(), tl.Float(), tl.Float(), tl.Float(), default_value=(1.0, 0, 0, 0))
+
+
+class RGBA(tl.TraitType):
+  default_value = Color(0., 0., 0., 1.0)
+  info_text = "an RGBA color"
+
+  def _validate(self, obj, value):
+    if isinstance(value, Color):
+      color = value
+    elif isinstance(value, int):
+      color = Color.from_hexint(value)
+    elif isinstance(value, str):
+      color = Color.from_hexstr(value)
+    elif len(value) in [3, 4]:
+      color = Color(*value)
+    else:
+      return self.error(obj, value)
+
+    if not len(color) == 4:
+      self.error(obj, value)
+    if not all([0 <= x <= 1 for x in color]):
+      self.error(obj, value)
+
+    return color
+
+
+# TODO: it is inconsistent to use Color object for RGBA and a regular tuple for RGB.
+#       But we do need both types. So maybe we should have both ColorRGBA and ColorRGB classes?
+class RGB(tl.TraitType):
+  default_value = (0., 0., 0.)
+  info_text = "an RGB color"
+
+  def _validate(self, obj, value):
+    if isinstance(value, Color):
+      color = value.rgb
+    elif isinstance(value, int):
+      color = Color.from_hexint(value).rgb
+    elif isinstance(value, str):
+      color = Color.from_hexstr(value).rgb
+    elif len(value) == 3:
+      color = value
+    else:
+      return self.error(obj, value)
+
+    if not len(color) == 3:
+      self.error(obj, value)
+    if not all([0 <= x <= 1 for x in color]):
+      self.error(obj, value)
+
+    return color

--- a/kubric/viewer/blender.py
+++ b/kubric/viewer/blender.py
@@ -31,8 +31,8 @@ class Blender:
   def __init__(self, scene: core.Scene):
     self.objects_to_blend = bidict()
 
-    self.illum_node = None
-    self.illum_hdri_node = None
+    self.ambient_node = None
+    self.ambient_hdri_node = None
     self.illum_mapping_node = None
     self.bg_node = None
     self.bg_hdri_node = None
@@ -136,15 +136,15 @@ class Blender:
     mix_node.location = 900, 0
     lightpath_node = tree.nodes.new(type='ShaderNodeLightPath')
     lightpath_node.location = 700, 350
-    self.illum_node = tree.nodes.new(type='ShaderNodeBackground')
-    self.illum_node.inputs['Color'].default_value = (0., 0., 0., 1.)
-    self.illum_node.location = 700, 0
+    self.ambient_node = tree.nodes.new(type='ShaderNodeBackground')
+    self.ambient_node.inputs['Color'].default_value = (0., 0., 0., 1.)
+    self.ambient_node.location = 700, 0
     self.bg_node = tree.nodes.new(type='ShaderNodeBackground')
     self.bg_node.inputs['Color'].default_value = (0., 0., 0., 1.)
     self.bg_node.location = 700, -120
 
     links.new(lightpath_node.outputs.get('Is Camera Ray'), mix_node.inputs.get('Fac'))
-    links.new(self.illum_node.outputs.get('Background'), mix_node.inputs[1])
+    links.new(self.ambient_node.outputs.get('Background'), mix_node.inputs[1])
     links.new(self.bg_node.outputs.get('Background'), mix_node.inputs[2])
     links.new(mix_node.outputs.get('Shader'), out_node.inputs.get('Surface'))
 
@@ -161,24 +161,24 @@ class Blender:
 
     self.illum_mapping_node = tree.nodes.new(type='ShaderNodeMapping')
     self.illum_mapping_node.location = 200, -200
-    self.illum_hdri_node = tree.nodes.new(type='ShaderNodeTexEnvironment')
-    self.illum_hdri_node.location = 400, -200
+    self.ambient_hdri_node = tree.nodes.new(type='ShaderNodeTexEnvironment')
+    self.ambient_hdri_node.location = 400, -200
     links.new(coord_node.outputs.get('Generated'), self.illum_mapping_node.inputs.get('Vector'))
-    links.new(self.illum_mapping_node.outputs.get('Vector'), self.illum_hdri_node.inputs.get('Vector'))
+    links.new(self.illum_mapping_node.outputs.get('Vector'), self.ambient_hdri_node.inputs.get('Vector'))
     # links.new(illum_hdri_node.outputs.get('Color'), self.illum_node.inputs.get('Color'))
 
-  def set_ambient_illumination(self, hdri_filepath=None, color=(0., 0., 0., 1.0), hdri_rotation=(0., 0., 0.)):
+  def set_ambient_light(self, hdri_filepath=None, color=(0., 0., 0., 1.0), hdri_rotation=(0., 0., 0.)):
     tree = bpy.context.scene.world.node_tree
     links = tree.links
     if hdri_filepath is None:
       # disconnect incoming links from hdri node (if any)
-      for link in self.illum_node.inputs['Color'].links:
+      for link in self.ambient_node.inputs['Color'].links:
         links.remove(link)
-      self.illum_node.inputs['Color'].default_value = color
+      self.ambient_node.inputs['Color'].default_value = color
     else:
       # ensure hdri_node is connected
-      links.new(self.illum_hdri_node.outputs.get('Color'), self.illum_node.inputs.get('Color'))
-      self.illum_hdri_node.image = bpy.data.images.load(hdri_filepath, check_existing=True)
+      links.new(self.ambient_hdri_node.outputs.get('Color'), self.ambient_node.inputs.get('Color'))
+      self.ambient_hdri_node.image = bpy.data.images.load(hdri_filepath, check_existing=True)
       self.illum_mapping_node.inputs.get('Rotation').default_value = hdri_rotation
 
   def set_background(self, hdri_filepath=None, color=(0., 0., 0., 1.0), hdri_rotation=(0., 0., 0.)):

--- a/kubric/viewer/blender.py
+++ b/kubric/viewer/blender.py
@@ -70,9 +70,7 @@ class Blender:
 
       # recursively add sub-assets
       value = getattr(obj, name)
-      print(obj, name, value)
       if isinstance(value, Asset):
-        print("HAHA: ", value, type(value), obj, name)
         value = self.add(value)
       # Initialize values
       setter(Munch(owner=obj, new=value, type='init'))

--- a/kubric/viewer/blender.py
+++ b/kubric/viewer/blender.py
@@ -335,8 +335,8 @@ class Destructor:
           bpy.data.objects.remove(obj, do_unlink=True)
         elif isinstance(obj, bpy.types.Material):
           bpy.data.materials.remove(obj, do_unlink=True)
-      except Exception as e:
-        print(e)
+      except ReferenceError:
+        pass  # In this case the object is already gone
 
 
 class Keyframer:

--- a/kubric/viewer/blender.py
+++ b/kubric/viewer/blender.py
@@ -1,5 +1,5 @@
 # Copyright 2020 The Kubric Authors
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -11,451 +11,99 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Implementation of blender backend."""
+
+import logging
+from functools import singledispatch
 
 import bpy
-from kubric.viewer import interface
+from bidict import bidict
+from munch import Munch
+from typing import Tuple, Dict
 
+from kubric.core import Asset, AttributeSetter
+from kubric import core
 
-# ------------------------------------------------------------------------------
-# ------------------------------------------------------------------------------
-# ------------------------------------------------------------------------------
+logger = logging.getLogger(__name__)
 
 
-class NotImplementableError(NotImplementedError):
-  """When a method in the interface cannot be realized in a particular implementation."""
-  pass
+class Blender:
+  def __init__(self, scene: core.Scene):
+    self.objects_to_blend = bidict()
 
+    self.illum_node = None
+    self.illum_hdri_node = None
+    self.illum_mapping_node = None
+    self.bg_node = None
+    self.bg_hdri_node = None
+    self.bg_mapping_node = None
 
-# ------------------------------------------------------------------------------
-# ------------------------------------------------------------------------------
-# ------------------------------------------------------------------------------
-
-
-class Object3D(interface.Object3D):
-  # Mapping from interface properties to blender properties (used in keyframing).
-  _member_to_blender_data_path = {
-      "position": "location",
-      "quaternion": "rotation_quaternion"
-  }
-
-  def __init__(self, blender_object):  # , name=None):
-    super().__init__(self)
-    self._blender_object = blender_object
-    self._blender_object.rotation_mode = 'QUATERNION'
-    # if self.name: self._blender_object.name = self.name
-
-  def _set_position(self, value):
-    # (UI: click mesh > Transform > Location)
-    super()._set_position(value)
-    self._blender_object.location = self.position
-
-  def _set_scale(self, value):
-    # (UI: click mesh > Transform > Scale)
-    super()._set_scale(value)
-    self._blender_object.scale = self.scale
-
-  def _set_quaternion(self, value):
-    # (UI: click mesh > Transform > Rotation)
-    super()._set_quaternion(value)
-    self._blender_object.rotation_quaternion = self.quaternion
-
-  def keyframe_insert(self, member: str, frame: int):
-    assert hasattr(self, member), "cannot keyframe an undefined property"
-    data_path = Object3D._member_to_blender_data_path[member]
-    self._blender_object.keyframe_insert(data_path=data_path, frame=frame)
-
-
-# ------------------------------------------------------------------------------
-# ------------------------------------------------------------------------------
-# ------------------------------------------------------------------------------
-
-class Scene(interface.Scene):
-  # TODO: create a named scene, and refer via bpy.data.scenes['Scene']
-
-  def __init__(self):
-    super().__init__()
-    bpy.context.scene.render.fps = 24
-    bpy.context.scene.render.fps_base = 1.0
-
-  def _set_frame_start(self, value):
-    super()._set_frame_start(value)
-    bpy.context.scene.frame_start = value
-
-  def _set_frame_end(self, value):
-    super()._set_frame_end(value)
-    bpy.context.scene.frame_end = value
-
-  def add(self, obj):
-    bpy.context.scene.collection.objects.link(obj._blender_object)
-
-# ------------------------------------------------------------------------------
-# ------------------------------------------------------------------------------
-# ------------------------------------------------------------------------------                                       
-
-
-class Camera(interface.Camera, Object3D):
-  def __init__(self, name='Camera'):
-    self.camera = bpy.data.cameras.new(name)
-    cam_obj = bpy.data.objects.new(name, self.camera)
-
-    Object3D.__init__(self, cam_obj)
-
-
-class PerspectiveCamera(interface.PerspectiveCamera, Camera):
-  def __init__(self, name='Camera', focal_length=50.):
-    Camera.__init__(self, name)
-    interface.PerspectiveCamera.__init__(self, focal_length)
-    self.camera.type = 'PERSP'
-    self.camera.lens = focal_length
-
-
-class OrthographicCamera(interface.OrthographicCamera, Camera):
-  def __init__(self, left=-1, right=+1, top=+1, bottom=-1, near=.1, far=2000):
-    interface.OrthographicCamera.__init__(self, left, right, top, bottom, near,
-                                          far)
-    Camera.__init__(self)
-    # --- extra things to set
-    self.camera.type = 'ORTHO'
-    self.camera.ortho_scale = (right - left)
-
-
-# ------------------------------------------------------------------------------
-# ------------------------------------------------------------------------------
-# ------------------------------------------------------------------------------
-
-# TODO: maybe deprecate in favor of renderer.set_up_background since it does the same but better
-class AmbientLight(interface.AmbientLight):
-  def __init__(self, color=0x030303, intensity=1):
-    interface.AmbientLight.__init__(self, color=color, intensity=intensity)
-
-  def _set_color(self, value):
-    super()._set_color(value)
-    bpy.context.scene.world.node_tree.nodes["Background"].inputs[
-      'Color'].default_value = self.color
-
-  def _set_intensity(self, value):
-    super()._set_intensity(value)
-    bpy.context.scene.world.node_tree.nodes["Background"].inputs[
-      'Strength'].default_value = self.intensity
-
-
-# ------------------------------------------------------------------------------
-# ------------------------------------------------------------------------------
-# ------------------------------------------------------------------------------
-
-
-class DirectionalLight(interface.DirectionalLight, Object3D):
-  def __init__(self, color=0xffffff, intensity=1, shadow_softness=.1):
-    self.sun = bpy.data.lights.new('Sun', 'SUN')
-    sun_obj = bpy.data.objects.new('Sun', self.sun)
-    Object3D.__init__(self, sun_obj)
-
-    interface.DirectionalLight.__init__(self, color=color, intensity=intensity,
-                                        shadow_softness=shadow_softness)
-
-  def _set_color(self, value):
-    super()._set_color(value)
-    self.sun.color = self.color[:3]  # ignore alpha
-
-  def _set_intensity(self, value):
-    super()._set_intensity(value)
-    self.sun.energy = self.intensity
-
-  def _set_shadow_softness(self, value):
-    super()._set_shadow_softness(value)
-    self.sun.angle = self.shadow_softness
-
-
-class RectAreaLight(interface.RectAreaLight, Object3D):
-  def __init__(self, color=0xffffff, intensity=1, width=.1, height=0.1):
-    self.area = bpy.data.lights.new('Area', 'AREA')
-    self.area.shape = 'RECTANGLE'
-    area_obj = bpy.data.objects.new('Area', self.area)
-    Object3D.__init__(self, area_obj)
-
-    interface.RectAreaLight.__init__(self, color=color, intensity=intensity,
-                                     width=width, height=height)
-
-  def _set_width(self, value):
-    super()._set_width(value)
-    self.area.size = value
-
-  def _set_height(self, value):
-    super()._set_height(value)
-    self.area.size_y = value
-
-  def _set_color(self, value):
-    super()._set_color(value)
-    self.area.color = self.color[:3]  # ignore alpha
-
-  def _set_intensity(self, value):
-    super()._set_intensity(value)
-    self.area.energy = self.intensity
-
-
-# ------------------------------------------------------------------------------
-# ------------------------------------------------------------------------------
-# ------------------------------------------------------------------------------
-
-
-class BufferAttribute(interface.BufferAttribute):
-  pass
-
-
-class Float32BufferAttribute(interface.Float32BufferAttribute):
-  def __init__(self, array, itemSize, normalized=None):
-    self.array = array  # TODO: @property
-
-
-# ------------------------------------------------------------------------------
-# ------------------------------------------------------------------------------
-# ------------------------------------------------------------------------------
-
-
-class Geometry():
-  pass
-
-
-class DummyGeometry(interface.Geometry, Geometry):
-  """Used by Mesh.from_file to inherit Object3D from file loader."""
-  def __init__(self, blender_object):
-    self._blender_object = blender_object
-
-
-class BoxGeometry(interface.BoxGeometry, Geometry):
-  def __init__(self, width=1.0, height=1.0, depth=1.0):
-    assert width == height and width == depth, "blender only creates unit cubes"
-    interface.BoxGeometry.__init__(self, width=width, height=height,
-                                   depth=depth)
-    bpy.ops.mesh.primitive_cube_add(size=width)
-    self._blender_object = bpy.context.object
-
-
-class PlaneGeometry(interface.Geometry, Geometry):
-  def __init__(self, width: float = 1, height: float = 1,
-      widthSegments: int = 1, heightSegments: int = 1):
-    assert widthSegments == 1 and heightSegments == 1, "not implemented"
-    bpy.ops.mesh.primitive_plane_add()
-    self._blender_object = bpy.context.object
-
-
-class BufferGeometry(interface.BufferGeometry, Geometry):
-  def __init__(self):
-    interface.BufferGeometry.__init__(self)
-
-  def set_index(self, nparray):
-    interface.BufferGeometry.set_index(self, nparray)
-
-  def set_attribute(self, name, attribute: interface.BufferAttribute):
-    interface.BufferGeometry.set_attribute(self, name, attribute)
-
-
-# ------------------------------------------------------------------------------
-# ------------------------------------------------------------------------------
-# ------------------------------------------------------------------------------
-
-
-class Material(interface.Material):
-  def __init__(self, specs={}):
-    # TODO: is this the same as object3D? guess not?
-    self._blender_material = bpy.data.materials.new('Material')
-
-  def blender_apply(self, blender_object):
-    """Used by materials that need to access the blender object.
-    e.g. flat shading in blender."""
-    pass
-
-
-class DummyMaterial(Material):
-  def __init__(self, blender_material):
-    self._blender_material = blender_material
-  
-
-class MeshBasicMaterial(interface.MeshBasicMaterial, Material):
-  def __init__(self, specs={}):
-    Material.__init__(self, specs)
-    interface.MeshBasicMaterial.__init__(self, specs)
-
-
-class MeshPhongMaterial(interface.MeshPhongMaterial, Material):
-  def __init__(self, specs={}):
-    Material.__init__(self, specs)
-    interface.Material.__init__(self, specs=specs)
-    # TODO: apply specs
-
-  def blender_apply(self, blender_object):
-    bpy.context.view_layer.objects.active = blender_object
-    bpy.ops.object.shade_smooth()
-
-
-class MeshFlatMaterial(interface.MeshFlatMaterial, Material):
-  def __init__(self, specs={}):
-    Material.__init__(self, specs)
-    interface.Material.__init__(self, specs=specs)
-
-  def blender_apply(self, blender_object):
-    bpy.context.view_layer.objects.active = blender_object
-    bpy.ops.object.shade_flat()
-
-
-class MeshChromeMaterial(interface.MeshBasicMaterial, Material):
-  def __init__(self, color_hsv=(1.0,1.0,1.0), roughness=.5):
-    color_rgba = interface.hsv_to_rgba(color_hsv)
-
-    # --- Create node-based material
-    self._blender_material = bpy.data.materials.new('Chrome')
-    self._blender_material.use_nodes = True
-    tree = self._blender_material.node_tree
-
-    # --- Specify nodes
-    LW = tree.nodes.new('ShaderNodeLayerWeight')
-    LW.inputs[0].default_value = 0.7
-    CR = tree.nodes.new('ShaderNodeValToRGB')
-    CR.color_ramp.elements[0].position = 0.9
-    CR.color_ramp.elements[0].color = color_rgba
-    CR.color_ramp.elements[1].position = 1
-    CR.color_ramp.elements[1].color = (0,0,0,1)
-    GLO = tree.nodes.new('ShaderNodeBsdfGlossy')
-    GLO.inputs[1].default_value = roughness
-
-    # --- link nodes
-    tree.links.new(LW.outputs[1], CR.inputs['Fac'])
-    tree.links.new(CR.outputs['Color'], GLO.inputs['Color'])
-    tree.links.new(GLO.outputs[0], tree.nodes['Material Output'].inputs['Surface'])
-
-
-class ShadowMaterial(interface.ShadowMaterial, Material):
-  def __init__(self, specs={}):
-    Material.__init__(self, specs=specs)
-    interface.ShadowMaterial.__init__(self, specs=specs)
-
-  def blender_apply(self, blender_object):
-    if self.receive_shadow:
-      blender_object.cycles.is_shadow_catcher = True
-
-
-# ------------------------------------------------------------------------------
-# ------------------------------------------------------------------------------
-# ------------------------------------------------------------------------------
-
-
-class Mesh(interface.Mesh, Object3D):
-  def __init__(self, geometry: Geometry, material: Material):
-    interface.Mesh.__init__(self, geometry, material)
-
-    # --- Create the blender object
-    # WARNING: differently from threejs, blender creates an object when
-    # primivitives are created, so we need to make sure we do not duplicate it
-    if hasattr(geometry, "_blender_object"):
-      # TODO: is there a better way to achieve this?
-      Object3D.__init__(self, geometry._blender_object)
-    else:
-      bpy.ops.object.add(type="MESH")
-      Object3D.__init__(self, bpy.context.object)
-
-    # --- Assigns the buffers to the object
-    # TODO: is there a better way to achieve this?
-    if isinstance(self.geometry, BufferGeometry):
-      vertices = self.geometry.attributes["position"].array.tolist()
-      faces = self.geometry.index.tolist()
-      self._blender_object.data.from_pydata(vertices, [], faces)
-
-    # --- Adds the material to the object (single materia/object)
-    self.set_material(material)
-
-  def set_material(self, material: Material):
-    """Clears all materials, and sets active_material to the given one."""
-    self.material = material
-    self._blender_object.data.materials.clear()
-    self._blender_object.data.materials.append(material._blender_material)
-    self._blender_object.active_material = material._blender_material
-
-  @classmethod
-  def from_file(cls, path: str, axis_forward='Y', axis_up='Z', name=None):
-    bpy.ops.import_scene.obj(filepath=str(path), axis_forward=axis_forward, axis_up=axis_up)
-
-    # --- Extract blender_object from scene 
-    # WARNING: bpy.context.object does not work here...
-    blender_objects = bpy.context.selected_objects[:]
-    assert len(blender_objects) == 1
-    blender_object = blender_objects[0]
-
-    # --- Create a mesh object
-    if name: blender_object.name = name  # TODO: naming should be centralized
-    # TODO: are the dummy classes the best way to achieve this?
-    material = DummyMaterial(blender_object.active_material)
-    geometry = DummyGeometry(blender_object)
-    return cls(geometry, material)
-
-
-# ------------------------------------------------------------------------------
-# ------------------------------------------------------------------------------
-# ------------------------------------------------------------------------------
-
-
-class Renderer(interface.Renderer):
-
-  def __init__(self, useBothCPUGPU=False):
-    super().__init__()
-    self.clear_scene()  # as blender has a default scene on load
+    self.clear_and_reset()  # as blender has a default scene on load
+    # the ray-tracing engine is set here because it affects the availability of some features
     bpy.context.scene.render.engine = 'CYCLES'
-    bpy.context.scene.cycles.samples = 128
-    bpy.context.scene.cycles.max_bounces = 6
-    bpy.context.scene.cycles.film_exposure = 1.5
+    self.add(scene)
+    self.set_up_scene_shading()
 
+  def add(self, obj: Asset):
+    if obj in self.objects_to_blend:
+      return self.objects_to_blend[obj]
+    blender_obj, setters = add_object(obj)
 
-    # activate further render passes
-    view_layer = bpy.context.scene.view_layers['View Layer']
-    view_layer.cycles.use_denoising = True
-    view_layer.use_pass_vector = True  # flow
-    view_layer.use_pass_uv = True  # UV
-    view_layer.use_pass_normal = True  # surface normals
-    view_layer.cycles.use_pass_crypto_object = True  # segmentation
-    view_layer.cycles.pass_crypto_depth = 2
+    # set the name of the object to the UID
+    blender_obj.name = obj.uid
+    # if it has a rotation mode, then make sure it is set to quaternions
+    if hasattr(blender_obj, 'rotation_mode'):
+      blender_obj.rotation_mode = 'QUATERNION'
 
-    # --- compute devices
-    # derek, why is the rationale? → rendering on GPU only sometime faster than CPU+GPU
-    # TODO: modify the logic to execute on CPU, GPU, CPU+GPU
-    cyclePref = bpy.context.preferences.addons['cycles'].preferences
-    cyclePref.compute_device_type = 'CUDA'
-    for dev in cyclePref.devices:
-      if dev.type == "CPU" and useBothCPUGPU is False:
-        dev.use = False
-      else:
-        dev.use = True
-    bpy.context.scene.cycles.device = 'GPU'
-    for dev in cyclePref.devices:
-      print(dev)
-      print(dev.use)
+    # remember object association
+    self.objects_to_blend[obj] = blender_obj
 
-  def set_background_transparent(self, film_transparent: bool):
-    bpy.context.scene.render.film_transparent = film_transparent
+    # if object is an actual Object (eg. not a Scene, or a Material)
+    # then ensure that it is linked into (used by) the current scene collection
+    if isinstance(blender_obj, bpy.types.Object):
+      collection = bpy.context.scene.collection.objects
+      if blender_obj not in collection.values():
+        collection.link(blender_obj)
 
-  def set_size(self, width: int, height: int):
-    super().set_size(width, height)
-    bpy.context.scene.render.resolution_x = self.width
-    bpy.context.scene.render.resolution_y = self.height
+    for name, setter in setters.items():
+      setter.mapping = self.objects_to_blend
 
-  def set_clear_color(self, color: int, alpha: float):
-    raise NotImplementableError()
+      # recursively add sub-assets
+      value = getattr(obj, name)
+      if isinstance(value, Asset):
+        value = self.add(value)
+      # Initialize values
+      setter(Munch(owner=obj, new=value, type='init'))
+      # Link values
+      obj.observe(setter, names=[name])
 
-  def clear_scene(self):
-    bpy.ops.wm.read_homefile()
-    bpy.ops.object.select_all(action='SELECT')
-    bpy.ops.object.delete()
+    obj.destruction_callbacks.append(Destructor([blender_obj]))
+    obj.keyframe_callbacks.append(Keyframer(setters))
 
-  def default_camera_view(self):
-    """Changes the UI so that the default view is from the camera POW."""
-    view3d = next(
-        area for area in bpy.context.screen.areas if area.type == 'VIEW_3D')
-    view3d.spaces[0].region_3d.view_perspective = 'CAMERA'
+    return blender_obj
+
+  def get_blender_object(self, obj: core.Object3D) -> bpy.types.Object:
+    if isinstance(obj, bpy.types.Object):
+      return obj
+    elif isinstance(obj, core.Object3D):
+      return self.objects_to_blend[obj]
+    else:
+      raise ValueError('Not a valid object {}'.format(obj))
+
+  def clear_and_reset(self):
+    bpy.ops.wm.read_factory_settings(use_empty=True)
+    bpy.context.scene.world = bpy.data.worlds.new('World')
 
   def set_up_exr_output(self, path):
     bpy.context.scene.use_nodes = True
     tree = bpy.context.scene.node_tree
     links = tree.links
-    render_node = tree.nodes.get('Render Layers')
+
+    # clear existing nodes
+    for node in tree.nodes:
+      tree.nodes.remove(node)
+
+    # the render node has outputs for all the rendered layers
+    render_node = tree.nodes.new(type="CompositorNodeRLayers")
 
     # create a new FileOutput node
     out_node = tree.nodes.new(type='CompositorNodeOutputFile')
@@ -470,20 +118,7 @@ class Renderer(interface.Renderer):
       out_node.file_slots.new(l)
       links.new(render_node.outputs.get(l), out_node.inputs.get(l))
 
-  def set_up_background(self, hdri_filepath=None, bg_color=None,
-                             hdri_rotation=(0.0, 0.0, 0.0)):
-    """
-    Use an HDRI file for global illumination, and/or render background with solid color.
-
-
-
-    Args:
-      hdri_filepath (str): path to the HDRI file.
-      bg_color: RGBA value of rendered background color.
-      hdri_rotation: XYZ euler angles for rotating the HDRI image.
-    """
-    assert hdri_filepath is not None or bg_color is not None
-
+  def set_up_scene_shading(self):
     bpy.context.scene.world.use_nodes = True
     tree = bpy.context.scene.world.node_tree
     links = tree.links
@@ -496,92 +131,199 @@ class Renderer(interface.Renderer):
     out_node = tree.nodes.new(type='ShaderNodeOutputWorld')
     out_node.location = 1100, 0
 
-    if hdri_filepath is not None:
-      coord_node = tree.nodes.new(type='ShaderNodeTexCoord')
-      mapping_node = tree.nodes.new(type='ShaderNodeMapping')
-      mapping_node.location = 200, 0
-      hdri_node = tree.nodes.new(type='ShaderNodeTexEnvironment')
-      hdri_node.location = 400, 0
-      light_bg_node = tree.nodes.new(type='ShaderNodeBackground')
-      light_bg_node.location = 700, 0
+    mix_node = tree.nodes.new(type='ShaderNodeMixShader')
+    mix_node.location = 900, 0
+    lightpath_node = tree.nodes.new(type='ShaderNodeLightPath')
+    lightpath_node.location = 700, 350
+    self.illum_node = tree.nodes.new(type='ShaderNodeBackground')
+    self.illum_node.inputs['Color'].default_value = (0., 0., 0., 1.)
+    self.illum_node.location = 700, 0
+    self.bg_node = tree.nodes.new(type='ShaderNodeBackground')
+    self.bg_node.inputs['Color'].default_value = (0., 0., 0., 1.)
+    self.bg_node.location = 700, -120
 
-      # link nodes
-      links.new(coord_node.outputs.get('Generated'), mapping_node.inputs.get('Vector'))
-      links.new(mapping_node.outputs.get('Vector'), hdri_node.inputs.get('Vector'))
-      links.new(hdri_node.outputs.get('Color'), light_bg_node.inputs.get('Color'))
+    links.new(lightpath_node.outputs.get('Is Camera Ray'), mix_node.inputs.get('Fac'))
+    links.new(self.illum_node.outputs.get('Background'), mix_node.inputs[1])
+    links.new(self.bg_node.outputs.get('Background'), mix_node.inputs[2])
+    links.new(mix_node.outputs.get('Shader'), out_node.inputs.get('Surface'))
 
-      # load the actual image
-      hdri_node.image = bpy.data.images.load(hdri_filepath, check_existing=True)
-      # set the rotation
-      mapping_node.inputs.get('Rotation').default_value = hdri_rotation  # XYZ rotation of HDRI bg
+    # create nodes for HDRI images, but leave them disconnected until set_ambient_illumination or set_background
+    coord_node = tree.nodes.new(type='ShaderNodeTexCoord')
 
-      # if no background color is set, then connect to output node
-      if bg_color is None:
-        links.new(light_bg_node.outputs.get('Background'), out_node.inputs.get('Surface'))
+    self.bg_mapping_node = tree.nodes.new(type='ShaderNodeMapping')
+    self.bg_mapping_node.location = 200, 200
+    self.bg_hdri_node = tree.nodes.new(type='ShaderNodeTexEnvironment')
+    self.bg_hdri_node.location = 400, 200
+    links.new(coord_node.outputs.get('Generated'), self.bg_mapping_node.inputs.get('Vector'))
+    links.new(self.bg_mapping_node.outputs.get('Vector'), self.bg_hdri_node.inputs.get('Vector'))
+    #links.new(bg_hdri_node.outputs.get('Color'), self.bg_node.inputs.get('Color'))
 
-    if bg_color is not None:
-      camera_bg_node = tree.nodes.new(type='ShaderNodeBackground')
-      camera_bg_node.location = 700, -120
-      # set bg color value
-      camera_bg_node.inputs.get('Color').default_value = bg_color  # BG color RGBA
+    self.illum_mapping_node = tree.nodes.new(type='ShaderNodeMapping')
+    self.illum_mapping_node.location = 200, -200
+    self.illum_hdri_node = tree.nodes.new(type='ShaderNodeTexEnvironment')
+    self.illum_hdri_node.location = 400, -200
+    links.new(coord_node.outputs.get('Generated'), self.illum_mapping_node.inputs.get('Vector'))
+    links.new(self.illum_mapping_node.outputs.get('Vector'), self.illum_hdri_node.inputs.get('Vector'))
+    # links.new(illum_hdri_node.outputs.get('Color'), self.illum_node.inputs.get('Color'))
 
-      # if no HDRI image is set, then connect to output node
-      if hdri_filepath is None:
-        links.new(camera_bg_node.outputs.get('Background'), out_node.inputs.get('Surface'))
-
-    # if both are set, then use a mixing node and a lightpath input
-    if hdri_filepath is not None and bg_color is not None:
-      mix_node = tree.nodes.new(type='ShaderNodeMixShader')
-      mix_node.location = 900, 0
-      lightpath_node = tree.nodes.new(type='ShaderNodeLightPath')
-      lightpath_node.location = 700, 350
-
-      links.new(lightpath_node.outputs.get('Is Camera Ray'), mix_node.inputs.get('Fac'))
-      links.new(light_bg_node.outputs.get('Background'), mix_node.inputs[1])
-      links.new(camera_bg_node.outputs.get('Background'), mix_node.inputs[2])
-      links.new(mix_node.outputs.get('Shader'), out_node.inputs.get('Surface'))
-
-  def render(self, scene: Scene, camera: Camera, path: str,
-      on_render_write=None):
-    # --- adjusts resolution according to threejs style camera
-    if isinstance(camera, OrthographicCamera):
-      aspect = (camera.right - camera.left) * 1.0 / (camera.top - camera.bottom)
-      new_y_res = int(bpy.context.scene.render.resolution_x / aspect)
-      if new_y_res != bpy.context.scene.render.resolution_y:
-        print("WARNING: blender renderer adjusted the film resolution", end="")
-        print(new_y_res, bpy.context.scene.render.resolution_y)
-        bpy.context.scene.render.resolution_y = new_y_res
-
-    # --- Sets the default camera
-    bpy.context.scene.camera = camera._blender_object
-
-    if not path.endswith(".blend"):
-      bpy.context.scene.render.filepath = path
-
-    # --- creates blender file
-    if path.endswith(".blend"):
-      self.default_camera_view()  # TODO: not saved... why?
-      bpy.ops.wm.save_mainfile(filepath=path)
-
-    # --- renders a movie
-    elif path.endswith(".mov"):
-      # WARNING: movies do not support transparency
-      # TODO: actually they do, ask @bydeng for the needed blender config.
-      assert bpy.context.scene.render.film_transparent == False
-      bpy.context.scene.render.image_settings.file_format = "FFMPEG"
-      bpy.context.scene.render.image_settings.color_mode = "RGB"
-      bpy.context.scene.render.ffmpeg.format = "QUICKTIME"
-      bpy.context.scene.render.ffmpeg.codec = "H264"
-
-    # --- renders one frame directly to a png file
-    elif path.endswith(".png"):
-      # TODO: add capability bpy.context.scene.frame_set(frame_number)
-      bpy.ops.render.render(write_still=True, animation=False)
-
-    # --- creates a movie as a image sequence {png}
+  def set_ambient_illumination(self, hdri_filepath=None, color=(0., 0., 0., 1.0), hdri_rotation=(0., 0., 0.)):
+    tree = bpy.context.scene.world.node_tree
+    links = tree.links
+    if hdri_filepath is None:
+      # disconnect incoming links from hdri node (if any)
+      for link in self.illum_node.inputs['Color'].links:
+        links.remove(link)
+      self.illum_node.inputs['Color'].default_value = color
     else:
-      if on_render_write:
-        bpy.app.handlers.render_write.append(
-          lambda scene: on_render_write(scene.render.frame_path()))
-      # Convert to gif via ImageMagick: `convert -delay 8 -loop 0 *.png output.gif`
-      bpy.ops.render.render(write_still=True, animation=True)
+      # ensure hdri_node is connected
+      links.new(self.illum_hdri_node.outputs.get('Color'), self.illum_node.inputs.get('Color'))
+      self.illum_hdri_node.image = bpy.data.images.load(hdri_filepath, check_existing=True)
+      self.illum_mapping_node.inputs.get('Rotation').default_value = hdri_rotation
+
+  def set_background(self, hdri_filepath=None, color=(0., 0., 0., 1.0), hdri_rotation=(0., 0., 0.)):
+    tree = bpy.context.scene.world.node_tree
+    links = tree.links
+    if hdri_filepath is None:
+      # disconnect incoming links from hdri node (if any)
+      for link in self.bg_node.inputs['Color'].links:
+        links.remove(link)
+      self.bg_node.inputs['Color'].default_value = color
+    else:
+      # ensure hdri_node is connected
+      links.new(self.bg_hdri_node.outputs.get('Color'), self.bg_node.inputs.get('Color'))
+      self.bg_hdri_node.image = bpy.data.images.load(hdri_filepath, check_existing=True)
+      self.bg_mapping_node.inputs.get('Rotation').default_value = hdri_rotation
+
+  def activate_render_passes(self):
+    view_layer = bpy.context.scene.view_layers[0]
+    view_layer.use_pass_vector = True  # flow
+    view_layer.use_pass_uv = True  # UV
+    view_layer.use_pass_normal = True  # surface normals
+    view_layer.cycles.use_pass_crypto_object = True  # segmentation
+    view_layer.cycles.pass_crypto_depth = 2
+
+  def set_size(self, width: int, height: int):
+    bpy.context.scene.render.resolution_x = width
+    bpy.context.scene.render.resolution_y = height
+
+  def render(self, path):
+    bpy.context.scene.cycles.use_adaptive_sampling = True  # speeds up rendering
+    bpy.context.scene.view_layers[0].cycles.use_denoising = True  # improves the output quality
+    self.activate_render_passes()
+    self.set_up_exr_output(path)
+
+    print("-"*80)
+    print(bpy.context.scene.frame_start)
+    print(bpy.context.scene.frame_end)
+    print(bpy.context.scene.render.fps)
+
+    bpy.ops.render.render(animation=True, write_still=True)
+
+
+# ########## Functions to import kubric objects into blender ###########
+
+
+@singledispatch
+def add_object(obj: Asset) -> Tuple[bpy.types.Object, Dict[str, AttributeSetter]]:
+  raise NotImplementedError()
+
+
+@add_object.register(core.FileBasedObject)
+def _add_object(obj: core.FileBasedObject):
+  # TODO: support other file-formats
+  # TODO: add material assignments
+  bpy.ops.import_scene.obj(filepath=str(obj.render_filename),
+                           axis_forward=obj.front, axis_up=obj.up)
+  assert len(bpy.context.selected_objects) == 1
+  blender_obj = bpy.context.selected_objects[0]
+
+  setters = {
+      'position': AttributeSetter(blender_obj, 'location'),
+      'quaternion': AttributeSetter(blender_obj, 'rotation_quaternion'),
+      'scale': AttributeSetter(blender_obj, 'scale')}
+  return blender_obj, setters
+
+
+@add_object.register(core.DirectionalLight)
+def _add_object(obj: core.DirectionalLight):
+  sun = bpy.data.lights.new(obj.uid, 'SUN')
+  sun_obj = bpy.data.objects.new(obj.uid, sun)
+
+  setters = {
+      'position': AttributeSetter(sun_obj, 'location'),
+      'quaternion': AttributeSetter(sun_obj, 'rotation_quaternion'),
+      'scale': AttributeSetter(sun_obj, 'scale'),
+      'color': AttributeSetter(sun, 'color'),
+      'intensity': AttributeSetter(sun, 'energy')}
+  return sun_obj, setters
+
+
+@add_object.register(core.RectAreaLight)
+def _add_object(obj: core.RectAreaLight):
+  area = bpy.data.lights.new(obj.uid, 'AREA')
+  area_obj = bpy.data.objects.new(obj.uid, area)
+
+  setters = {
+      'position': AttributeSetter(area_obj, 'location'),
+      'quaternion': AttributeSetter(area_obj, 'rotation_quaternion'),
+      'scale': AttributeSetter(area_obj, 'scale'),
+      'color': AttributeSetter(area, 'color'),
+      'intensity': AttributeSetter(area, 'energy'),
+      'width': AttributeSetter(area, 'size'),
+      'height': AttributeSetter(area, 'size_y')}
+  return area_obj, setters
+
+
+@add_object.register(core.PerspectiveCamera)
+def _add_object(obj: core.PerspectiveCamera):
+  camera = bpy.data.cameras.new(obj.uid)
+  camera.type = 'PERSP'
+  camera_obj = bpy.data.objects.new(obj.uid, camera)
+
+  setters = {
+      'position': AttributeSetter(camera_obj, 'location'),
+      'quaternion': AttributeSetter(camera_obj, 'rotation_quaternion'),
+      'scale': AttributeSetter(camera_obj, 'scale'),
+      'focal_length': AttributeSetter(camera, 'lens'),
+      'sensor_width': AttributeSetter(camera, 'sensor_width')}
+  return camera_obj, setters
+
+
+@add_object.register(core.Scene)
+def _add_scene(obj: core.Scene):
+  blender_scene = bpy.context.scene
+
+  setters = {
+      'frame_start': AttributeSetter(blender_scene, 'frame_start'),
+      'frame_end': AttributeSetter(blender_scene, 'frame_end'),
+      'frame_rate': AttributeSetter(blender_scene.render, 'fps'),
+      'resolution': AttributeSetter(blender_scene.render, ['resolution_x', 'resolution_y']),
+      'camera': AttributeSetter(blender_scene, 'camera')
+  }
+  return blender_scene, setters
+
+
+# ########### ########### ########### ########### ########### ########### ########### ##########
+
+class Destructor:
+  def __init__(self, blender_objects):
+    self.blender_objects = blender_objects
+
+  def __call__(self, owner=None):
+    for obj in self.blender_objects:
+      try:
+        if isinstance(obj, bpy.types.Object):
+          bpy.data.objects.remove(obj, do_unlink=True)
+        elif isinstance(obj, bpy.types.Material):
+          bpy.data.materials.remove(obj, do_unlink=True)
+      except Exception as e:
+        print(e)
+
+
+class Keyframer:
+  def __init__(self, setters):
+    self.setters = setters
+
+  def __call__(self, owner, member, frame):
+    setter = self.setters[member]
+    setter.blender_obj.keyframe_insert(setter.blender.name, frame=frame)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pytest
 mathutils
 dataclasses
 hypothesis
+traitlets

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ OpenEXR
 pytest
 mathutils
 dataclasses
+hypothesis

--- a/test/test_color.py
+++ b/test/test_color.py
@@ -1,0 +1,80 @@
+# Copyright 2020 The Kubric Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import pytest
+
+from hypothesis import given
+from hypothesis.strategies import floats, tuples, text
+
+
+from kubric.color import Color
+
+
+@pytest.mark.parametrize('hexint, expected', [
+    (0x000000, Color(0., 0., 0., 1.)),
+    (0xff0000, Color(1., 0., 0., 1.)),
+    (0x00ff00, Color(0., 1., 0., 1.)),
+    (0x0000ff, Color(0., 0., 1., 1.)),
+    (0xffffff, Color(1., 1., 1., 1.)),
+])
+def test_hex_to_rgb(hexint, expected):
+  assert Color.from_hexint(hexint) == expected
+
+
+def test_hex_to_rgba():
+  assert Color.from_hexint(0xffffff, alpha=0.5) == (1., 1., 1., 0.5)
+
+
+def test_hex_to_rgba_invalid():
+  with pytest.raises(ValueError):
+    Color.from_hexint(-1)
+
+  with pytest.raises(ValueError):
+    Color.from_hexint(0xfffffff)
+
+  with pytest.raises(ValueError):
+    Color.from_hexint(0x000000, alpha=-0.1)
+
+  with pytest.raises(ValueError):
+    Color.from_hexint(0x123456, alpha=1.1)
+
+
+@given(tuples(floats(0., 1.0), floats(0.01, 1.0), floats(0.01, 1.0)))
+def test_hsv_conversion_is_invertable(hsv):
+  assert Color.from_hsv(*hsv).hsv == pytest.approx(hsv)
+
+
+@given(text(alphabet='0123456789abcdef', min_size=6, max_size=6))
+def test_hexstr_rgb_conversion_is_invertable(hexstr):
+  hexstr = '#' + hexstr
+  assert Color.from_hexstr(hexstr).hexstr == hexstr + 'ff'
+
+
+@given(text(alphabet='0123456789abcdef', min_size=8, max_size=8))
+def test_hexstr_rgba_conversion_is_invertable(hexstr):
+  hexstr = '#' + hexstr
+  assert Color.from_hexstr(hexstr).hexstr == hexstr
+
+
+@given(text(alphabet='0123456789abcdef', min_size=3, max_size=3))
+def test_hexstr_short_rgb_conversion_is_invertable(hexstr_short):
+  hexstr_short = '#' + hexstr_short
+  assert Color.from_hexstr(hexstr_short).hexstr_short == hexstr_short + 'f'
+
+
+@given(text(alphabet='0123456789abcdef', min_size=4, max_size=4))
+def test_hexstr_short_rgba_conversion_is_invertable(hexstr_short):
+  hexstr_short = '#' + hexstr_short
+  assert Color.from_hexstr(hexstr_short).hexstr_short == hexstr_short

--- a/test/test_traits.py
+++ b/test/test_traits.py
@@ -1,0 +1,75 @@
+# Copyright 2020 The Kubric Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import pytest
+import traitlets as tl
+
+from kubric.traits import Quaternion, Vector3D, RGB, RGBA
+
+
+@pytest.fixture
+def obj():
+  class TestObject(tl.HasTraits):
+    quaternion = Quaternion()
+    position = Vector3D()
+    scale = Vector3D(default_value=(1., 1., 1.))
+    rgb = RGB()
+    rgba = RGBA()
+
+  return TestObject()
+
+
+def test_default_values(obj):
+  assert obj.quaternion == (1, 0, 0, 0)
+  assert obj.position == (0, 0, 0)
+  assert obj.scale == (1, 1, 1)
+  assert obj.rgb == (0, 0, 0)
+  assert obj.rgba == (0, 0, 0, 1)
+
+
+def test_set_sequence(obj):
+  obj.quaternion = (1, 2, 3, 4)
+  assert obj.quaternion == (1, 2, 3, 4)
+
+  obj.quaternion = [1, 2, 3, 4]
+  assert obj.quaternion == (1, 2, 3, 4)
+
+  obj.position = (3, 2, 1)
+  assert obj.position == (3, 2, 1)
+
+  obj.scale = [2, 2, 2]
+  assert obj.scale == (2, 2, 2)
+
+  obj.rgb = (0.5, 0.2, 0.1)
+  assert obj.rgb == (0.5, 0.2, 0.1)
+
+  obj.rgba = [1., 0.8, 0.6, 0.4]
+  assert obj.rgba == (1., 0.8, 0.6, 0.4)
+
+
+def test_raises_on_invalid_sequence_length(obj):
+  with pytest.raises(tl.TraitError):
+    obj.position = (1, 2, 3, 4)
+
+  with pytest.raises(tl.TraitError):
+    obj.quaternion = (1, 2, 3)
+
+  with pytest.raises(tl.TraitError):
+    obj.rgb = (1, 1, 1, 1)
+
+  with pytest.raises(tl.TraitError):
+    obj.rgba = (1, 1)
+
+

--- a/test/test_traits.py
+++ b/test/test_traits.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+import numpy as np
 import pytest
 import traitlets as tl
 
@@ -48,6 +48,9 @@ def test_set_sequence(obj):
 
   obj.position = (3, 2, 1)
   assert obj.position == (3, 2, 1)
+
+  obj.position = np.array([0.1, 0.2, 0.3])
+  assert obj.position == (0.1, 0.2, 0.3)
 
   obj.scale = [2, 2, 2]
   assert obj.scale == (2, 2, 2)

--- a/worker.py
+++ b/worker.py
@@ -141,6 +141,23 @@ objects_list = [
 ]
 
 
+def random_material(asset_id, rnd):
+  color = Color.from_hsv(rnd.rand(), .95, 1.0)
+  if 'Metal' in asset_id:
+    return core.PrincipledBSDFMaterial(
+        color=color.rgb,
+        roughness=0.2,
+        metallic=1.0,
+        ior=2.5)
+  else: # if 'Rubber' in asset_id:
+    return core.PrincipledBSDFMaterial(
+        color=color.rgb,
+        roughness=0.7,
+        specular=0.33,
+        metallic=0.,
+        ior=1.25)
+
+
 def get_random_rotation(rnd):
   """Samples a random rotation around z axis (uniformly distributed)."""
   theta = rnd.uniform(0, 2*np.pi)
@@ -149,10 +166,12 @@ def get_random_rotation(rnd):
 
 objects = []
 for i in range(nr_objects):
-  objects.append(asset_source.create(rnd.choice(objects_list),
+  asset_id = rnd.choice(objects_list)
+  objects.append(asset_source.create(asset_id,
                                      {'position': tuple(rnd.uniform(*spawn_region)),
                                       'quaternion': get_random_rotation(rnd),
-                                      'linear_velocity': tuple(rnd.uniform(*velocity_range))}))
+                                      'velocity': tuple(rnd.uniform(*velocity_range)),
+                                      'material': random_material(asset_id, rnd)}))
 
 for obj in objects:
   simulator.add(obj)
@@ -175,6 +194,7 @@ animation = simulator.run()
 
 
 for obj in objects:
+  renderer.add(obj)
   # --- Bake the simulation into keyframes
   for frame_id in range(scene.frame_start, scene.frame_end):
     obj.position = animation[obj]["position"][frame_id]

--- a/worker.py
+++ b/worker.py
@@ -68,17 +68,10 @@ scene = Scene(frame_start=FLAGS.frame_start,
 # --- Download a few models locally
 asset_source = KLEVR(uri=FLAGS.assets)
 simulator = Simulator(scene)
-renderer = Blender(scene)
 
 # --- Scene static geometry
 floor, lights, camera = asset_source.get_scene()
 simulator.add(floor)
-renderer.add(floor)
-for light in lights:
-  renderer.add(light)
-renderer.add(camera)
-
-scene.camera = camera
 
 # --- Scene configuration (number of objects randomly scattered in a region)
 nr_objects = rnd.randint(4, 10)
@@ -100,7 +93,12 @@ animation = simulator.run()
 # ------------------------------------------------------------------------------
 # ------------------------------------------------------------------------------
 # ------------------------------------------------------------------------------
-
+renderer = Blender(scene)
+renderer.add(floor)
+for light in lights:
+  renderer.add(light)
+renderer.add(camera)
+scene.camera = camera   # TODO: currently camera has to be added to renderer before assignment. fix!
 
 for obj in objects:
   renderer.add(obj)

--- a/worker.py
+++ b/worker.py
@@ -27,16 +27,18 @@ from kubric.viewer.blender import Blender
 # ------------------------------------------------------------------------------
 
 parser = argparse.ArgumentParser()
-parser.add_argument("--assets", type=str, default="KLEVR",
+parser.add_argument("--assets", type=str, default="./KLEVR",
                     help="e.g. '~/datasets/katamari' or 'gs://kubric/katamari'")
 parser.add_argument("--frame_rate", type=int, default=24)
 parser.add_argument("--step_rate", type=int, default=240)
 parser.add_argument("--frame_start", type=int, default=0)
 parser.add_argument("--frame_end", type=int, default=96)  # 4 seconds 
 parser.add_argument("--logging_level", type=str, default="INFO")
+parser.add_argument("--max_placement_trials", type=int, default=100)
 parser.add_argument("--seed", type=int, default=0)
-parser.add_argument("--resolution", type=int, default=512)
-parser.add_argument("--output", type=str, default='./output/')  # TODO: actually copy results there
+parser.add_argument("--width", type=int, default=512)
+parser.add_argument("--height", type=int, default=512)
+parser.add_argument("--output", type=str, default="./output/")  # TODO: support cloud storage
 
 # --- parse argument in a way compatible with blender's REPL
 if "--" in sys.argv:
@@ -50,7 +52,6 @@ else:
 
 # --- Setup logger
 logging.basicConfig(level=FLAGS.logging_level)
-logger = logging.getLogger(__name__)
 
 # --- Configures random generator
 if FLAGS.seed:
@@ -62,7 +63,7 @@ scene = Scene(frame_start=FLAGS.frame_start,
               frame_end=FLAGS.frame_end,
               frame_rate=FLAGS.frame_rate,
               step_rate=FLAGS.step_rate,
-              resolution=(FLAGS.resolution, FLAGS.resolution))
+              resolution=(FLAGS.width, FLAGS.height))
 
 
 # --- Download a few models locally
@@ -80,12 +81,12 @@ objects = [asset_source.get_random_object(rnd) for _ in range(nr_objects)]
 for obj in objects:
   collision = simulator.add(obj)
   trial = 0
-  while collision and trial < 100:
+  while collision and trial < FLAGS.max_placement_trials:
     obj.position, obj.rotation = asset_source.get_random_object_pose(obj.name, rnd)
     collision = simulator.check_overlap(obj)
     trial += 1
   if collision:
-    raise RuntimeError('Failed to place', obj)
+    raise RuntimeError("Failed to place", obj)
 
 # --- run the physics simulation
 animation = simulator.run()
@@ -94,6 +95,7 @@ animation = simulator.run()
 # ------------------------------------------------------------------------------
 # ------------------------------------------------------------------------------
 renderer = Blender(scene)
+renderer.set_ambient_light()
 renderer.add(floor)
 for light in lights:
   renderer.add(light)
@@ -106,8 +108,8 @@ for obj in objects:
   for frame_id in range(scene.frame_start, scene.frame_end):
     obj.position = animation[obj]["position"][frame_id]
     obj.quaternion = animation[obj]["quaternion"][frame_id]
-    obj.keyframe_insert('position', frame_id)
-    obj.keyframe_insert('quaternion', frame_id)
+    obj.keyframe_insert("position", frame_id)
+    obj.keyframe_insert("quaternion", frame_id)
 
 # --- Render or create the .blend file
 renderer.render(path=FLAGS.output)


### PR DESCRIPTION
The main interface of Kubric now builds on the [`traitlets`](https://github.com/ipython/traitlets) package.

The idea is that for things like 3D objects or lights, there are corresponding classes in [`core.py`](https://github.com/google-research/kubric/blob/klausg_refactor/kubric/core.py). 
They define traits for controllable parameters such as position or color.
Both PyBullet and Blender then register observers for those traits such that every change to that object is mirrored in simulation and rendering.
