### PR TITLE
Fixed some missing dependencies and path handling

### DIFF
--- a/kubric/assets/klevr.py
+++ b/kubric/assets/klevr.py
@@ -43,7 +43,7 @@ class KLEVR(asset_source.AssetSource):
     self.ambient_light = (0.05, 0.05, 0.05)
 
   def get_scene_geometry(self):
-    return self.create(asset_id="Floor", static=True, position=(0, 0, -0.2))
+    return self.create(asset_id="Floor", static=True, position=(0, 0, -0.2), scale=(2, 2, 2))
 
   def get_lights(self):
     # --- Light settings from CLEVR

--- a/kubric/viewer/blender.py
+++ b/kubric/viewer/blender.py
@@ -109,7 +109,7 @@ class Blender:
     out_node = tree.nodes.new(type="CompositorNodeOutputFile")
     # set the format to EXR (multilayer)
     out_node.format.file_format = "OPEN_EXR_MULTILAYER"
-    out_node.base_path = path  # output directory
+    out_node.base_path = str(path)  # output directory
 
     layers = ["Image", "Depth", "Vector", "UV", "Normal", "CryptoObject00"]
 
@@ -207,14 +207,15 @@ class Blender:
     bpy.context.scene.render.resolution_y = height
 
   def render(self, path):
+    path = pathlib.Path(path)
     bpy.context.scene.cycles.use_adaptive_sampling = True  # speeds up rendering
     bpy.context.scene.view_layers[0].cycles.use_denoising = True  # improves the output quality
-    bpy.context.scene.render.filepath = path
+    bpy.context.scene.render.filepath = str(path / "frame_")
 
     self.activate_render_passes()
-    self.set_up_exr_output(path)
+    self.set_up_exr_output(path / "frame_")
 
-    bpy.ops.wm.save_mainfile(filepath=str(pathlib.Path(path) / "out.blend"))
+    bpy.ops.wm.save_mainfile(filepath=str(path / "scene.blend"))
 
     bpy.ops.render.render(animation=True, write_still=True)
 

--- a/make_kubruntu.sh
+++ b/make_kubruntu.sh
@@ -48,6 +48,8 @@ cat > /tmp/Dockerfile <<EOF
   RUN python3.7 -m pip install --upgrade --force-reinstall google.cloud.storage
   RUN python3.7 -m pip install --upgrade --force-reinstall cloudml-hypertune
   RUN python3.7 -m pip install --upgrade --force-reinstall OpenEXR
+  RUN python3.7 -m pip install --upgrade --force-reinstall munch
+  RUN python3.7 -m pip install --upgrade --force-reinstall traitlets
 EOF
 
 # --- create an image for reuse

--- a/worker.py
+++ b/worker.py
@@ -14,6 +14,8 @@
 
 import argparse
 import logging
+import pathlib
+
 import numpy as np
 
 import sys; sys.path.append(".")
@@ -113,4 +115,6 @@ for obj in objects:
     obj.keyframe_insert("quaternion", frame_id)
 
 # --- Render or create the .blend file
+output_path = pathlib.Path(FLAGS.output)
+output_path.mkdir(parents=True, exist_ok=True)
 renderer.render(path=FLAGS.output)

--- a/worker.py
+++ b/worker.py
@@ -41,7 +41,8 @@ parser.add_argument("--max_placement_trials", type=int, default=100)
 parser.add_argument("--seed", type=int, default=0)
 parser.add_argument("--width", type=int, default=512)
 parser.add_argument("--height", type=int, default=512)
-parser.add_argument("--output", type=str, default="./output/")  # TODO: support cloud storage
+# TODO: support cloud storage
+parser.add_argument("--output", type=str, default="./output/", help="output directory")
 
 # --- parse argument in a way compatible with blender's REPL
 if "--" in sys.argv:
@@ -117,4 +118,4 @@ for obj in objects:
 # --- Render or create the .blend file
 output_path = pathlib.Path(FLAGS.output)
 output_path.mkdir(parents=True, exist_ok=True)
-renderer.render(path=FLAGS.output)
+renderer.render(path=output_path)


### PR DESCRIPTION
1. Some dependencies had not been added to `make_kubruntu.sh`. Added them. Though we should move to `requirement.txt` for the docker image (see #57)
2. The output path handling was confusing and the worker failed if the output directory did not exist. The worker now creates the output directory if it doesn't exists, and the results are always stored in `$OUTPUT/scene.blend`, `$OUTPUT/frame_0000.png` and `$OUTPUT/frame_0000.exr` respectively.