### PR TITLE
Added Asset(name="...") logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,14 @@ docs: $(shell find docs )
 docs_server:
 	cd docs/_build/html && python3 -m http.server 8000
 
+# --- shared variables for example executions
+UID:=$(shell id -u)
+GID:=$(shell id -g)
+
+# --- one-liners for executing examples
+examples/helloworld:
+	docker run --rm --interactive --user $(UID):$(GID) --volume $(PWD):/kubric kubricdockerhub/kubruntudev python3 examples/helloworld.py
+
 clean:
 	python3 setup.py clean --all
 	rm -rf kubric.egg-info

--- a/examples/helloworld.py
+++ b/examples/helloworld.py
@@ -15,17 +15,17 @@
 import logging
 import kubric as kb
 
-logging.basicConfig(level="WARNING") #< CRITICAL, ERROR, WARNING, INFO, DEBUG
+logging.basicConfig(level="INFO") #< CRITICAL, ERROR, WARNING, INFO, DEBUG
 
 # --- create scene and attach a renderer to it
 scene = kb.Scene(resolution=(256, 256))
 renderer = kb.renderer.Blender(scene)
 
 # --- populate the scene with objects, lights, cameras
-scene += kb.Cube(scale=(10, 10, 0.1), position=(0, 0, -0.1))
-scene += kb.Sphere(scale=1, position=(0, 0, .5))
-scene += kb.DirectionalLight(position=(-1, -0.5, 3), look_at=(0, 0, 0), intensity=1.5)
-scene += kb.PerspectiveCamera(position=(2, -0.5, 4), look_at=(0, 0, 0))
+scene += kb.Cube(name="floor", scale=(10, 10, 0.1), position=(0, 0, -0.1))
+scene += kb.Sphere(name="ball", scale=1, position=(0, 0, .5))
+scene += kb.DirectionalLight(name="sun", position=(-1, -0.5, 3), look_at=(0, 0, 0), intensity=1.5)
+scene += kb.PerspectiveCamera(name="camera", position=(2, -0.5, 4), look_at=(0, 0, 0))
 
 # --- render (and save the blender file) 
 renderer.save_state("output/helloworld.blend")

--- a/examples/simulator.py
+++ b/examples/simulator.py
@@ -27,9 +27,9 @@ simulator = kb.simulator.PyBullet(scene)
 renderer = kb.renderer.Blender(scene)
 
 # --- populate the scene with objects, lights, cameras
-scene += kb.Cube(scale=(3, 3, 0.1), position=(0, 0, -0.1), static=True)
-scene += kb.DirectionalLight(position=(-1, -0.5, 3), look_at=(0, 0, 0), intensity=1.5)
-scene.camera = kb.PerspectiveCamera(position=(2, -0.5, 4), look_at=(0, 0, 0))
+scene += kb.Cube(name="floor", scale=(3, 3, 0.1), position=(0, 0, -0.1), static=True)
+scene += kb.DirectionalLight(name="sun", position=(-1, -0.5, 3), look_at=(0, 0, 0), intensity=1.5)
+scene.camera = kb.PerspectiveCamera(name="camera", position=(2, -0.5, 4), look_at=(0, 0, 0))
 
 # --- generates spheres randomly within a spawn region
 spawn_region = [[-1, -1, 0], [1, 1, 1]]

--- a/kubric/core/base.py
+++ b/kubric/core/base.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO(klaus): shouldn't this logic be moved to util.py, and this file renamed to asset.py?
-
 import collections
 import contextlib
 
@@ -79,7 +77,8 @@ class Asset(tl.HasTraits):
     # e.g. if self.name="Cube", the UIDs of the first three: {"Cube", "Cube.001", "Cube.002"}
     # Matches blender naming logic, and allows lexicographical sorting of the first 999 instances.
 
-    # Undefined assets (e.g. UndefinedMaterial) are singletons and do not have a name
+    # Undefined assets (e.g. UndefinedMaterial) are singletons and thus their uid is always equal 
+    # to their name (without an instance counter)
     if isinstance(self, Undefined):
       return f"{self.name}"
     

--- a/kubric/core/base.py
+++ b/kubric/core/base.py
@@ -65,14 +65,10 @@ class Asset(tl.HasTraits):
   metadata = tl.Dict(key_trait=tl.ObjectName())
 
   def __init__(self, **kwargs):
-    # --- ensure all constructor arguments are used
-    # TODO(klaus): this logic could be moved to util.py? (quite generic) 
-    initializable_traits = self.trait_names()
-    initializable_traits.remove("uid")
-    unknown_traits = [kwarg for kwarg in kwargs if kwarg not in initializable_traits]
-    if unknown_traits:
-      raise KeyError(f"Cannot initialize unknown trait(s) {unknown_traits}. "
-                     f"Possible traits are: {initializable_traits}")
+    # --- ensure all constructor arguments are traits
+    unknown_traits = [kwarg for kwarg in kwargs if kwarg not in self.trait_names()]
+    if unknown_traits: 
+      raise KeyError(f"Cannot initialize unknown trait(s) {unknown_traits}.")
 
     # --- Change the basename used by the UID creation mechanism
     name = self.__class__.__name__ if "name" not in kwargs else kwargs["name"]
@@ -84,7 +80,7 @@ class Asset(tl.HasTraits):
     self.scenes = []
     self.keyframes = collections.defaultdict(dict)
 
-    # --- Initialize others
+    # --- Initialize traits
     super().__init__(**kwargs)
 
   @property

--- a/kubric/core/scene.py
+++ b/kubric/core/scene.py
@@ -22,6 +22,7 @@ from kubric.core import base
 from kubric.core import objects
 from kubric.core import cameras
 from kubric.core import color
+from kubric.utils import next_global_count
 
 __all__ = ("Scene",)
 
@@ -77,7 +78,7 @@ class Scene(tl.HasTraits):
   @tl.default("uid")
   def _uid(self):
     name = self.__class__.__name__
-    return f"{name}.{base.next_global_count(name):03d}"
+    return f"{name}.{next_global_count(name):03d}"
 
   @tl.validate("step_rate")
   def _valid_step_rate(self, proposal):

--- a/kubric/utils.py
+++ b/kubric/utils.py
@@ -35,6 +35,8 @@ import pprint
 import shutil
 import sys
 import tempfile
+import collections
+import multiprocessing
 
 import numpy as np
 import tensorflow as tf
@@ -216,3 +218,22 @@ def done():
   hpt.report_hyperparameter_tuning_metric(
       hyperparameter_metric_tag="answer",
       metric_value=42)
+
+# --------------------------------------------------------------------------------------------------
+# --------------------------------------------------------------------------------------------------
+# --------------------------------------------------------------------------------------------------
+
+def next_global_count(name, reset=False):
+  """A global counter to create UIDs.
+  Return the total number of times (0-indexed) the function has been called with the given name.
+  Used to create the increasing UID counts for each class (e.g. "Sphere.007").
+  When passing reset=True, then all counts are reset.
+  """
+  if reset or not hasattr(next_global_count, "counter"):
+    next_global_count.counter = collections.defaultdict(int)
+    next_global_count.lock = multiprocessing.Lock()
+
+  with next_global_count.lock:
+    counter = next_global_count.counter[name]
+    next_global_count.counter[name] += 1
+    return counter


### PR DESCRIPTION
Also fixed save_state to prevent duplicate ".blend{1,2,...}" files from being created.
**warning** @Qwlouse to match Blender's logic, the first instance is not `cube.001` but rather `cube`, and the second instance will be `cube.001`.

**Please confirm this does not create problems.**

![Screen Shot 2021-06-07 at 4 00 21 PM](https://user-images.githubusercontent.com/4480573/121098165-2390ec00-c7aa-11eb-9bf5-fea43450a061.png)


As an example, see the `examples/simulator.py` (with multiple spheres):
![Screen Shot 2021-06-07 at 4 08 13 PM](https://user-images.githubusercontent.com/4480573/121098417-a7e36f00-c7aa-11eb-9ca9-4c26e72431d6.png)
