### PR TITLE
pypi with tag-based versioning

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,16 +9,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
         python-version: 3.7
-    - name: Install python requirements
+    
+    - name: Install packaging requirements
       run: |
         python -m pip install --upgrade pip
-        pip install -U -r requirements.txt
+        pip install -U packaging
         pip install -U setuptools
+        pip install -U wheel
         pip install -U twine
+    
     - name: Build package and upload to test.pypi
       env:
         TWINE_USERNAME: ${{ secrets.TEST_PYPI_USERNAME }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,6 +24,6 @@ jobs:
         TWINE_USERNAME: ${{ secrets.TEST_PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD }}
       run: |
-        python setup.py sdist bdist_wheel
+        python setup.py sdist bdist_wheel --nightly
         twine check dist/*
         twine upload --repository testpypi dist/*

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -31,5 +31,10 @@ jobs:
         echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
 
     - name: executing setup w/ a particular tag
+      env:
+        TWINE_USERNAME: ${{ secrets.TEST_PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD }}
       run: |
         python3 setup.py sdist bdist_wheel --tag=${{ steps.get_version.outputs.VERSION }}
+        twine check dist/*
+        twine upload --repository testpypi dist/*

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -17,12 +17,12 @@ jobs:
       with:
         python-version: 3.7
 
-    # - name: Install python requirements
-    #   run: |
-    #     python -m pip install --upgrade pip
-    #     pip install -U -r requirements.txt
-    #     pip install -U setuptools
-    #     pip install -U twine
+    - name: Install python requirements
+      run: |
+        python -m pip install --upgrade pip
+        pip install -U packaging
+        pip install -U setuptools
+        pip install -U twine
 
     - name: fetching the git tag that triggered the action
       id: get_version

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -2,7 +2,9 @@ name: pypi.yml
 
 on:
   push:
-    tags:
+    branches:    
+      - main
+    tags:        
       - '*'
 
 jobs:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,23 @@
+name: pypi.yml
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  deploy:
+    if: github.repository == 'google-research/kubric'  # prevents action from running on forks
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Install python requirements
+      run: |
+        python -m pip install --upgrade pip
+        pip install -U -r requirements.txt
+        pip install -U setuptools
+        pip install -U twine

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -11,19 +11,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
         python-version: 3.7
+
     # - name: Install python requirements
     #   run: |
     #     python -m pip install --upgrade pip
     #     pip install -U -r requirements.txt
     #     pip install -U setuptools
     #     pip install -U twine
+
     - name: fetching the git tag that triggered the action
       id: get_version
-      run: 
+      run: |
         echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
-    - name: checking whether the tag is correct
-      run: echo ${{ steps.get_version.outputs.VERSION }}
+
+    - name: executing setup w/ a particular tag
+      run: |
+        python3 setup.py sdist bdist_wheel --tag=${{ steps.get_version.outputs.VERSION }}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -2,8 +2,6 @@ name: pypi.yml
 
 on:
   push:
-    branches:    
-      - main
     tags:        
       - '*'
 

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -15,9 +15,15 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.7
-    - name: Install python requirements
-      run: |
-        python -m pip install --upgrade pip
-        pip install -U -r requirements.txt
-        pip install -U setuptools
-        pip install -U twine
+    # - name: Install python requirements
+    #   run: |
+    #     python -m pip install --upgrade pip
+    #     pip install -U -r requirements.txt
+    #     pip install -U setuptools
+    #     pip install -U twine
+    - name: fetching the git tag that triggered the action
+      id: get_version
+      run: 
+        echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
+    - name: checking whether the tag is correct
+      run: echo ${{ steps.get_version.outputs.VERSION }}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -17,11 +17,12 @@ jobs:
       with:
         python-version: 3.7
 
-    - name: Install python requirements
+    - name: Install packaging requirements
       run: |
         python -m pip install --upgrade pip
         pip install -U packaging
         pip install -U setuptools
+        pip install -U wheel
         pip install -U twine
 
     - name: fetching the git tag that triggered the action

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ pylint:
 
 # --- manually publishes the package to pypi
 pypi_test/write: clean_build
-	python3 setup.py sdist bdist_wheel --microversioning
+	python3 setup.py sdist bdist_wheel --secondly
 	python3 -m twine check dist/*
 	python3 -m twine upload -u kubric --repository testpypi dist/*
 
@@ -76,11 +76,20 @@ pypi_test/write: clean_build
 pypi_test/read:
 	@virtualenv --quiet --system-site-packages -p python3 /tmp/testenv
 	@/tmp/testenv/bin/pip3 install \
-		--upgrade --quiet \
+		--upgrade --no-cache-dir \
 		--index-url https://test.pypi.org/simple \
 		--extra-index-url https://pypi.org/simple \
-		kubric==$${VERSION}
+		kubric-secondly==$${VERSION}
 	@/tmp/testenv/bin/python3 examples/basic.py
+
+# --- tagging (+auto-push to pypi via actions)
+tag:
+	git log --pretty=oneline
+	@read -p "shah of commit to tag: " SHAH
+	@read -p "tag name (e.g. v0.1): " TAG
+	@read -p "tag description: " MESSAGE
+	git tag -a $${TAG} -m $${MESSAGE} $${SHAH}
+	git push origin --tags
 
 # --- trashes the folders created by "python3 setup.py"
 clean_build:

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ if args.tag is not None:
   NAME="kubric"
 if args.nightly:
   VERSION = f"{now.year}.{now.month}.{now.day}"
-  NAME="kubric-nigthly"
+  NAME="kubric-nightly"
 if args.secondly or VERSION is None:  #< contingency plan
   VERSION = f"{now.year}.{now.month}.{now.day}.{now.hour}.{now.minute}.{now.second}"
   NAME="kubric-secondly"


### PR DESCRIPTION
@Qwlouse ready for merge (coded on master, but moved to pypi to create a PR for code review)

A version of kubric will be pushed to test.pypi whenever a new tag is created.
This can bed done in any branch by executing
1) `make tag`
2) `git tag -a v0.0.1 -m deleteme && git push origin --tags`
3) [creating a release in the github UI](https://github.com/google-research/kubric/releases/new)

A copy of the workflow was executed from the PR below