### PR TITLE
Added safeimport mechanism

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,8 @@ docs_server:
 	cd docs/_build/html && python3 -m http.server 8000
 
 # --- one-liners for executing examples
+examples/basic: checkmakeversion
+	python3 examples/basic.py
 examples/helloworld: checkmakeversion
 	docker run --rm --interactive --user `id -u`:`id -g` --volume `pwd`:/kubric kubricdockerhub/kubruntudev python3 examples/helloworld.py
 examples/simulator: checkmakeversion

--- a/examples/katr.py
+++ b/examples/katr.py
@@ -28,11 +28,11 @@
 import logging
 import pathlib
 
-import bpy
 import numpy as np
 import kubric as kb
 from kubric.renderer.blender import Blender as KubricRenderer
 from kubric.simulator.pybullet import PyBullet as KubricSimulator
+from kubric.safeimport.bpy import bpy
 
 # --- Some configuration values
 # the region in which to place objects [(min), (max)]

--- a/kubric/assets/asset_preprocessing.py
+++ b/kubric/assets/asset_preprocessing.py
@@ -20,9 +20,9 @@ import pathlib
 import tarfile
 import shutil
 
-import bpy
 import numpy as np
 import trimesh
+from kubric.safeimport.bpy import bpy
 
 
 URDF_TEMPLATE = """

--- a/kubric/renderer/blender.py
+++ b/kubric/renderer/blender.py
@@ -19,7 +19,7 @@ import sys
 from contextlib import redirect_stdout
 from typing import Any, Optional, Union
 
-import bpy
+from kubric.safeimport.bpy import bpy
 
 import numpy as np
 import tensorflow_datasets.public_api as tfds

--- a/kubric/renderer/blender_utils.py
+++ b/kubric/renderer/blender_utils.py
@@ -17,7 +17,6 @@ import logging
 import sys
 from typing import Dict, Sequence
 
-import bpy
 import numpy as np
 import OpenEXR
 import Imath
@@ -26,6 +25,7 @@ import sklearn.utils
 from kubric import core
 from kubric.custom_types import AddAssetFunction
 from kubric.redirect_io import RedirectStream
+from kubric.safeimport.bpy import bpy
 
 
 def clear_and_reset_blender_scene(verbose=False):

--- a/kubric/safeimport/bpy.py
+++ b/kubric/safeimport/bpy.py
@@ -1,0 +1,18 @@
+"""Module to safely import blender's bpy and guide the user to a solution.
+
+USAGE:
+  from kubric.safeimport.bpy import bpy
+"""
+
+__ERROR_MESSAGE__ = """
+Note: the `bpy` module used by kubric cannot be installed via pip. Most likely, you are
+executing this script within a raw python environment rather than in our docker container.
+Please refer to our documentation: https://readthedocs.org/projects/kubric
+"""
+
+try:
+  import bpy  # pylint: disable=unused-import
+except ImportError as err:
+  print(err)
+  print(__ERROR_MESSAGE__)
+  exit(1)

--- a/kubric/scripts/export_assets_from_blend.py
+++ b/kubric/scripts/export_assets_from_blend.py
@@ -28,7 +28,7 @@
 
 import argparse
 import logging
-import bpy
+from kubric.safeimport.bpy import bpy
 
 from kubric.assets.asset_preprocessing import export_collection
 

--- a/shapenet2kubric/bpy_clean_mesh.py
+++ b/shapenet2kubric/bpy_clean_mesh.py
@@ -27,7 +27,7 @@
 # limitations under the License.
 
 import argparse
-import bpy
+from kubric.safeimport.bpy import bpy
 
 
 def cleanup_mesh(asset_id: str, source_path: str, target_path: str):

--- a/test/test_blender.py
+++ b/test/test_blender.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import bpy
+from kubric.safeimport.bpy import bpy
 
 from kubric import core
 from kubric.renderer import blender


### PR DESCRIPTION
Objective: guide the user that attempts to use the module outside of the docker REPL.

For example, `basic.py` does not employ `bpy` internally, while `helloworld` does:
```
~/dev/kubric: python3 examples/basic.py 
executing '/Users/atagliasacchi/dev/kubric/examples/basic.py' with kubric==HEAD

~/dev/kubric: python3 examples/helloworld.py 
No module named 'bpy'

Note: the `bpy` module used by kubric cannot be installed via pip. Most likely, you are
executing this script within a raw python environment rather than in our docker container.
Please refer to our documentation: https://readthedocs.org/projects/kubric
```