### PR TITLE
Added launch.py (xmanager public API)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,10 @@ examples/katr: checkmakeversion
 examples/shapenet: checkmakeversion
 	docker run --rm --interactive --user `id -u`:`id -g` --volume `pwd`:/kubric kubricdockerhub/kubruntudev python3 examples/shapenet.py
 
+# --- xmanager launch attempt
+examples/helloworld/xmanager:
+	~/.local/bin/xmanager launch launch.py
+
 # --- runs the test suite within the dev container (similar to test.yml), e.g.
 # USAGE:
 # 	make pytest TEST=test/test_core.py

--- a/launch.py
+++ b/launch.py
@@ -1,0 +1,96 @@
+"""Usage: xmanager launch launch.py"""
+# FIXME: _JOB_NAME="kubric_$(date +"%b%d_%H%M%S" | tr A-Z a-z)"
+# FIXME: how to specify which cloud project we are using?
+
+from typing import Sequence
+
+from absl import app
+from absl import flags
+
+from google.cloud import aiplatform_v1beta1 as aip
+
+from xmanager import vizier
+from xmanager import xm
+from xmanager import xm_local
+
+# --- Flags
+_RUN_MODE = flags.DEFINE_enum("run_mode", "local", ["local", "remote", "hyper"],
+  "Should I run locally, one single copy remotely, or launch a sweep?")
+_CONTAINER = flags.DEFINE_string("container_tag",
+  "kubricdockerhub/kubruntudev:latest", "base containter")
+_REGION = flags.DEFINE_string("region", "us-central1",
+  "GCP execution region; WARNING: match region of bucket!")
+_JOB_NAME = flags.DEFINE_string("name", "", "Your name.")
+_NR_VIDEOS = flags.DEFINE_integer("nr_videos", 0, "Number of videos.", lower_bound=0)
+_NR_WORKERS = flags.DEFINE_integer("nr_workers", 0, "Number of workers.", lower_bound=0)
+_PREFIX = flags.DEFINE_string("prefix", "gs://research-brain-kubric-xgcp/jobs",
+  "where the output of the execution will be saved.")
+_PROJECT_D = flags.DEFINE_string("gcp_project", "kubric-xgcp",
+  "name of the GCP project that will execute the workload")
+
+
+# --- Container configuration.
+_DOCKERFILE = """
+cat > Dockerfile <<EOF
+FROM ${SOURCE_TAG}
+COPY ${worker_file} /worker/worker.py
+WORKDIR /kubric
+ENTRYPOINT ["python3", "/worker/worker.py"]
+"""
+
+
+def get_study_spec() -> aip.StudySpec:
+  return aip.StudySpec(
+      # FIXME: How to port these from the bash version?
+      # NOTE: we are executing a parfor [1..N] here, that"s all we need
+      # maxTrials: $NR_VIDEOS
+      # maxParallelTrials: $NR_WORKERS
+      # maxFailedTrials: 1000
+      # enableTrialEarlyStopping: False
+
+      parameters=[
+          aip.StudySpec.ParameterSpec(
+              parameter_id="seed",
+              double_value_spec=aip.StudySpec.ParameterSpec.IntegerValueSpec(
+                  min_value=-1, max_value=1000000)),
+      ],
+      metrics=[
+          aip.StudySpec.MetricSpec(
+              metric_id="answer", goal=aip.StudySpec.MetricSpec.GoalType.MAXIMIZE)
+      ])
+
+
+def main(_: Sequence[str]) -> None:
+  with xm_local.create_experiment(experiment_title="kubric_test") as experiment:
+    executable_spec = xm.Container(image_path=_CONTAINER.value)
+
+    if _RUN_MODE.value in ["local"]:
+      executor = xm_local.Local()  # FIXME: Mount /kubric, ../assets
+    else:
+      executor = xm_local.Caip(requirements = xm.JobRequirements(location=_REGION.value))
+
+    [executable] = experiment.package([
+      xm.Packageable(
+          executable_spec=executable_spec,
+          executor_spec=executor.Spec()),
+    ])
+
+    job = xm.Job(
+      executable=executable,
+      executor=executor,
+      # FIXME: Forward extra args (unparsed vararg) to jobs
+      args=[f"--job-dir '{_PREFIX.value}/{_JOB_NAME.value}'"]
+    )
+
+    if _RUN_MODE.value == "hyper":
+      vizier.VizierExploration(
+          experiment=experiment,
+          job=job,
+          study_factory=vizier.NewStudy(study_spec=get_study_spec()),
+          num_trials_total=_NR_VIDEOS.value,
+          num_parallel_trial_runs=_NR_WORKERS.value).launch()
+    else:
+      experiment.add(job)
+
+if __name__ == "__main__":
+  app.run(main)


### PR DESCRIPTION
Closes #165 
Minor changes to the code of @dfurrer

Install [xmanager](https://github.com/deepmind/xmanager) and launch with :
```
pip install xmanager
~/.local/bin/xmanager launch launch.py
```

Current outcome:
```
~/dev/kubric: make examples/helloworld/xmanager
~/.local/bin/xmanager launch launch.py
Traceback (most recent call last):
  File "~/.local/lib/python3.9/site-packages/docker/api/client.py", line 268, in _raise_for_status
    response.raise_for_status()
  File "/usr/lib/python3/dist-packages/requests/models.py", line 943, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 500 Server Error: Internal Server Error for url: http+docker://localhost/v1.41/distribution/kubricdockerhub/kubruntudev:latest/json

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "~/.local/bin/xmanager", line 8, in <module>
    sys.exit(entrypoint())
  File "~/.local/lib/python3.9/site-packages/xmanager/cli/cli.py", line 65, in entrypoint
    app.run(main)
  File "~/.local/lib/python3.9/site-packages/absl/app.py", line 303, in run
    _run_main(main, args)
  File "~/.local/lib/python3.9/site-packages/absl/app.py", line 251, in _run_main
    sys.exit(main(argv))
  File "~/.local/lib/python3.9/site-packages/xmanager/cli/cli.py", line 41, in main
    app.run(m.main, argv=argv)
  File "~/.local/lib/python3.9/site-packages/absl/app.py", line 303, in run
    _run_main(main, args)
  File "~/.local/lib/python3.9/site-packages/absl/app.py", line 251, in _run_main
    sys.exit(main(argv))
  File "~/dev/kubric/launch.py", line 72, in main
    [executable] = experiment.package([
  File "~/.local/lib/python3.9/site-packages/xmanager/xm/core.py", line 483, in package
    return cls._async_packager.package(packageables)
  File "~/.local/lib/python3.9/site-packages/xmanager/xm/async_packager.py", line 104, in package
    executables = self._package_batch(packageables)
  File "~/.local/lib/python3.9/site-packages/xmanager/xm_local/packaging/router.py", line 54, in package
    return [
  File "~/.local/lib/python3.9/site-packages/xmanager/xm_local/packaging/router.py", line 55, in <listcomp>
    _PACKAGING_ROUTER(packageable, packageable.executor_spec)
  File "~/.local/lib/python3.9/site-packages/xmanager/xm/pattern_matching.py", line 113, in apply
    return case.handle(*values)
  File "~/.local/lib/python3.9/site-packages/xmanager/xm_local/packaging/router.py", line 31, in _visit_local_spec
    return local_packaging.package_for_local_executor(packageable,
  File "~/.local/lib/python3.9/site-packages/xmanager/xm_local/packaging/local.py", line 129, in package_for_local_executor
    return _LOCAL_PACKAGING_ROUTER(packageable, executable_spec)
  File "~/.local/lib/python3.9/site-packages/xmanager/xm/pattern_matching.py", line 113, in apply
    return case.handle(*values)
  File "~/.local/lib/python3.9/site-packages/xmanager/xm_local/packaging/local.py", line 36, in _package_container
    elif instance.is_registry_label(container.image_path):
  File "~/.local/lib/python3.9/site-packages/xmanager/docker/docker_adapter.py", line 55, in is_registry_label
    self._client.images.get_registry_data(label)
  File "~/.local/lib/python3.9/site-packages/docker/models/images.py", line 335, in get_registry_data
    attrs=self.client.api.inspect_distribution(name, auth_config),
  File "~/.local/lib/python3.9/site-packages/docker/utils/decorators.py", line 34, in wrapper
    return f(self, *args, **kwargs)
  File "~/.local/lib/python3.9/site-packages/docker/utils/decorators.py", line 19, in wrapped
    return f(self, resource_id, *args, **kwargs)
  File "~/.local/lib/python3.9/site-packages/docker/api/image.py", line 287, in inspect_distribution
    return self._result(
  File "~/.local/lib/python3.9/site-packages/docker/api/client.py", line 274, in _result
    self._raise_for_status(response)
  File "~/.local/lib/python3.9/site-packages/docker/api/client.py", line 270, in _raise_for_status
    raise create_api_error_from_http_exception(e)
  File "~/.local/lib/python3.9/site-packages/docker/errors.py", line 31, in create_api_error_from_http_exception
    raise cls(e, response=response, explanation=explanation)
docker.errors.APIError: 500 Server Error for http+docker://localhost/v1.41/distribution/kubricdockerhub/kubruntudev:latest/json: Internal Server Error ("Head https://mirror.gcr.io/v2/kubricdockerhub/kubruntudev/manifests/latest: unauthorized: Not Authorized.")
make: *** [Makefile:61: examples/helloworld/xmanager] Error 1
```