### PR TITLE
Adding SpotLight to Lighting kit

### DIFF
--- a/kubric/__init__.py
+++ b/kubric/__init__.py
@@ -38,6 +38,7 @@ from kubric.core.lights import UndefinedLight
 from kubric.core.lights import DirectionalLight
 from kubric.core.lights import PointLight
 from kubric.core.lights import RectAreaLight
+from kubric.core.lights import SpotLight
 
 from kubric.core.materials import Material
 from kubric.core.materials import UndefinedMaterial

--- a/kubric/core/lights.py
+++ b/kubric/core/lights.py
@@ -33,7 +33,7 @@ class Light(objects.Object3D):
 
 class SpotLight(Light):
   spot_blend = tl.Float(1.)
-  spot_size = tl.Float(*(0.00, 180.00))
+  spot_size = tl.Float(np.pi / 4)
 
 
 class UndefinedLight(Light, UndefinedAsset):

--- a/kubric/core/lights.py
+++ b/kubric/core/lights.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Kubric lights module."""
 
+import numpy as np
 import traitlets as tl
 
 from kubric.core import traits as ktl

--- a/kubric/core/lights.py
+++ b/kubric/core/lights.py
@@ -31,6 +31,11 @@ class Light(objects.Object3D):
     return True
 
 
+class SpotLight(Light):
+  spot_blend = tl.Float(1.)
+  spot_size = tl.Float(*(0.00, 180.00))
+
+
 class UndefinedLight(Light, UndefinedAsset):
   pass
 

--- a/kubric/renderer/blender.py
+++ b/kubric/renderer/blender.py
@@ -478,7 +478,7 @@ class Blender(core.View):
   #@blender_utils.prepare_blender_object
   def _add_asset(self, obj: core.SpotLight):  # pylint: disable=function-redefined
     spotlight = bpy.data.lights.new(obj.uid, "SPOT")
-    spotlight_obj = bpy.data.objects.new(obj.uid, SpotLight)
+    spotlight_obj = bpy.data.objects.new(obj.uid, core.SpotLight)
 
     register_object3d_setters(obj, spotlight_obj)
     obj.observe(AttributeSetter(spotlight, "color"), "color")

--- a/kubric/renderer/blender.py
+++ b/kubric/renderer/blender.py
@@ -474,20 +474,22 @@ class Blender(core.View):
     obj.observe(KeyframeSetter(sun, "energy"), "intensity", type="keyframe")
     return sun_obj
 
+  #@add_asset.register(core.SpotLight) # I think these are needed... ~MrX
+  #@blender_utils.prepare_blender_object
   def _add_asset(self, obj: core.SpotLight):  # pylint: disable=function-redefined
-    SpotLight = bpy.data.lights.new(obj.uid, "SPOT")
-    SpotLight_obj = bpy.data.objects.new(obj.uid, SpotLight)
+    spotlight = bpy.data.lights.new(obj.uid, "SPOT")
+    spotlight_obj = bpy.data.objects.new(obj.uid, SpotLight)
 
-    register_object3d_setters(obj, SpotLight_obj)
-    obj.observe(AttributeSetter(SpotLight, "color"), "color")
-    obj.observe(KeyframeSetter(SpotLight, "color"), "color", type="keyframe")
-    obj.observe(AttributeSetter(SpotLight, "energy"), "intensity")
-    obj.observe(KeyframeSetter(SpotLight, "energy"), "intensity", type="keyframe")
-    obj.observe(AttributeSetter(SpotLight, "spot_blend"), "spot_blend")
-    obj.observe(KeyframeSetter(SpotLight, "spot_blend"), "spot_blend", type="keyframe")
-    obj.observe(AttributeSetter(SpotLight, "spot_size"), "spot_size")
-    obj.observe(KeyframeSetter(SpotLight, "spot_size"), "spot_size", type="keyframe")
-    return SpotLight_obj
+    register_object3d_setters(obj, spotlight_obj)
+    obj.observe(AttributeSetter(spotlight, "color"), "color")
+    obj.observe(KeyframeSetter(spotlight, "color"), "color", type="keyframe")
+    obj.observe(AttributeSetter(spotlight, "energy"), "intensity")
+    obj.observe(KeyframeSetter(spotlight, "energy"), "intensity", type="keyframe")
+    obj.observe(AttributeSetter(spotlight, "spot_blend"), "spot_blend")
+    obj.observe(KeyframeSetter(spotlight, "spot_blend"), "spot_blend", type="keyframe")
+    obj.observe(AttributeSetter(spotlight, "spot_size"), "spot_size")
+    obj.observe(KeyframeSetter(spotlight, "spot_size"), "spot_size", type="keyframe")
+    return spotlight_obj
 
 
   @add_asset.register(core.RectAreaLight)

--- a/kubric/renderer/blender.py
+++ b/kubric/renderer/blender.py
@@ -474,6 +474,22 @@ class Blender(core.View):
     obj.observe(KeyframeSetter(sun, "energy"), "intensity", type="keyframe")
     return sun_obj
 
+  def _add_asset(self, obj: core.SpotLight):  # pylint: disable=function-redefined
+    SpotLight = bpy.data.lights.new(obj.uid, "SPOT")
+    SpotLight_obj = bpy.data.objects.new(obj.uid, SpotLight)
+
+    register_object3d_setters(obj, SpotLight_obj)
+    obj.observe(AttributeSetter(SpotLight, "color"), "color")
+    obj.observe(KeyframeSetter(SpotLight, "color"), "color", type="keyframe")
+    obj.observe(AttributeSetter(SpotLight, "energy"), "intensity")
+    obj.observe(KeyframeSetter(SpotLight, "energy"), "intensity", type="keyframe")
+    obj.observe(AttributeSetter(SpotLight, "spot_blend"), "spot_blend")
+    obj.observe(KeyframeSetter(SpotLight, "spot_blend"), "spot_blend", type="keyframe")
+    obj.observe(AttributeSetter(SpotLight, "spot_size"), "spot_size")
+    obj.observe(KeyframeSetter(SpotLight, "spot_size"), "spot_size", type="keyframe")
+    return SpotLight_obj
+
+
   @add_asset.register(core.RectAreaLight)
   @blender_utils.prepare_blender_object
   def _add_asset(self, obj: core.RectAreaLight):

--- a/shapenet2kubric/convert.py
+++ b/shapenet2kubric/convert.py
@@ -296,7 +296,7 @@ def stage5(object_folder: Path, logger=_DEFAULT_LOGGER):
     tar.add(object_folder / 'kubric' / 'collision_geometry.obj',
             arcname='collision_geometry.obj')
     tar.add(object_folder / 'kubric' / 'model_watertight.obj',
-            arcname='collision_geometry.obj')
+            arcname='model_watertight.obj')
     tar.add(object_folder / 'kubric' / 'object.urdf',
             arcname='object.urdf')
     tar.add(object_folder / 'kubric' / 'data.json',


### PR DESCRIPTION
Added the spot_blend and spot_size parameters into the lights.py file.

Spot Blend is the roughness of the beam
Spot Size is the radius in deg 0 - 180 # This might be incorrect? 

Blender.py was changed to add the needed parameters inside the blender handler. I think I added the correct identifiers and what not. I just copied the standard implementation as it was written.

The SpotLight was added in with the other forms of Lights

----------
Personal Note:
Still need to look at the colors of the lights. Maybe refer to the issue in the main github of Kubric regarding the Color Class and its implementation and look at reworking for a more wide-spread color use. Need to look into the color implementation.