### PR TITLE
Allow kubric to set principal point shift for blender camera.

### DIFF
--- a/challenges/point_tracking/dataset.py
+++ b/challenges/point_tracking/dataset.py
@@ -1,3 +1,17 @@
+# Copyright 2023 The Kubric Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Kubric dataset with point tracking."""
 
 import functools

--- a/examples/shapenet.py
+++ b/examples/shapenet.py
@@ -1,3 +1,17 @@
+# Copyright 2023 The Kubric Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 import logging
 import numpy as np

--- a/kubric/core/cameras.py
+++ b/kubric/core/cameras.py
@@ -21,15 +21,13 @@ from kubric.kubric_typing import ArrayLike
 
 
 class Camera(objects.Object3D):
-  """ Base class for all types of cameras. 
-  
+  """Base class for all types of cameras.
+
   Args:
-    min_render_distance (float): The minimum rendering distance for the camera `m`.
-                          `Default = 0.1`
-
-    max_render_distance (float): The maximum rendering distance for the camera `m`.
-                          `Default = 1000.0`
-
+    min_render_distance (float): The minimum rendering distance for the camera
+      `m`. `Default = 0.1`
+    max_render_distance (float): The maximum rendering distance for the camera
+      `m`. `Default = 1000.0`
   """
 
   min_render_distance = tl.Float(0.1)
@@ -71,28 +69,54 @@ class UndefinedCamera(Camera, UndefinedAsset):
 
 
 class PerspectiveCamera(Camera):
-  """ A :class:`Camera` that uses perspective projection.
+  """A :class:`Camera` that uses perspective projection.
 
   Args:
-    focal_length (float): The focal length of the camera lens in `mm`.
-                          `Default = 50`
-
-    sensor_width (float): Horizontal size of the camera sensor in `mm`.
-                          `Default = 36`
-
+    focal_length (float): The focal length of the camera lens in `mm`. `Default
+      = 50`
+    sensor_width (float): Horizontal size of the camera sensor in `mm`. `Default
+      = 36`
+    shift_x (float): Principal point horizontal offset defined as fraction of
+      sensor width. `Default = 0.0`
+    shift_y (float): Principal point vertical offset defined as fraction of
+      sensor height. `Default = 0.0`
   """
 
   focal_length = tl.Float(50)
   sensor_width = tl.Float(36)
+  # Changing shift_x and shift_y is currently not supported in kubric. However,
+  # these values can be changed if only blender support is necessary as changing
+  # these will impact the blender camera principal point offsets.
+  shift_x = tl.Float(0.0)
+  shift_y = tl.Float(0.0)
 
-  def __init__(self,
-               focal_length: float = 50,
-               sensor_width: float = 36,
-               position=(0., 0., 0.),
-               quaternion=None, up="Y", front="-Z", look_at=None, euler=None, **kwargs):
-    super().__init__(focal_length=focal_length, sensor_width=sensor_width, position=position,
-                     quaternion=quaternion, up=up, front=front, look_at=look_at, euler=euler,
-                     **kwargs)
+  def __init__(
+      self,
+      focal_length: float = 50,
+      sensor_width: float = 36,
+      shift_x: float = 0.0,
+      shift_y: float = 0.0,
+      position=(0.0, 0.0, 0.0),
+      quaternion=None,
+      up="Y",
+      front="-Z",
+      look_at=None,
+      euler=None,
+      **kwargs
+  ):
+    super().__init__(
+        focal_length=focal_length,
+        sensor_width=sensor_width,
+        position=position,
+        quaternion=quaternion,
+        up=up,
+        front=front,
+        look_at=look_at,
+        euler=euler,
+        shift_x=shift_x,
+        shift_y=shift_y,
+        **kwargs
+    )
 
   @property
   def field_of_view(self) -> float:

--- a/kubric/datasets/movid.py
+++ b/kubric/datasets/movid.py
@@ -1,0 +1,14 @@
+# Copyright 2023 The Kubric Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/kubric/renderer/blender.py
+++ b/kubric/renderer/blender.py
@@ -191,7 +191,6 @@ class Blender(core.View):
                       if d.use]
       logger.info("Using the following GPU Device(s): %s", devices_used)
 
-
   def set_exr_output_path(self, path_prefix: Optional[PathLike]):
     """Set the target path prefix for EXR output.
 
@@ -347,7 +346,6 @@ class Blender(core.View):
 
     return {key: np.stack(data_stack[key], axis=0)
             for key in data_stack}
-
 
   @staticmethod
   def clear_and_reset_blender_scene(verbose: bool = False, custom_scene: str = None):
@@ -549,6 +547,10 @@ class Blender(core.View):
     obj.observe(KeyframeSetter(camera, "clip_start"), "min_render_distance", type="keyframe")
     obj.observe(AttributeSetter(camera, "clip_end"), "max_render_distance")
     obj.observe(KeyframeSetter(camera, "clip_end"), "max_render_distance", type="keyframe")
+    obj.observe(AttributeSetter(camera, "shift_x"), "shift_x")
+    obj.observe(KeyframeSetter(camera, "shift_x"), "shift_x", type="keyframe")
+    obj.observe(AttributeSetter(camera, "shift_y"), "shift_y")
+    obj.observe(KeyframeSetter(camera, "shift_y"), "shift_y", type="keyframe")
     return camera_obj
 
   @add_asset.register(core.OrthographicCamera)

--- a/kubric/safeimport/bpy.py
+++ b/kubric/safeimport/bpy.py
@@ -1,3 +1,17 @@
+# Copyright 2023 The Kubric Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Module to safely import blender's bpy and guide the user to a solution.
 
 USAGE:

--- a/shapenet2kubric/shapenet_synsets.py
+++ b/shapenet2kubric/shapenet_synsets.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright 2023 The Kubric Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+#!/usr/bin/env python3
 
 CATEGORY_NAMES = {
     "04250224": "sniper rifle",

--- a/shapenet2kubric/trimesh_utils.py
+++ b/shapenet2kubric/trimesh_utils.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright 2023 The Kubric Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+#!/usr/bin/env python3
 
 import json
 import sys

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -11,3 +11,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+


### PR DESCRIPTION
Allow kubric to set principal point shift for blender camera.

Note that this cl, however, does not handle the support for principal points in kubric.
