### PR TITLE
fix refactoring bugs in movi_def_worker

### DIFF
--- a/challenges/movi/README.md
+++ b/challenges/movi/README.md
@@ -477,7 +477,7 @@ docker run --rm --interactive \
   kubricdockerhub/kubruntu    \
   /usr/bin/python3 challenges/movi/movi_def_worker.py \
   --camera=linear_movement_linear_lookat \
-  --max_camera_motion=8.0
+  --max_camera_movement=8.0
 ```
 
 See [movi_e.py](movi_e.py) for the TFDS definition / conversion.

--- a/challenges/movi/movi_def_worker.py
+++ b/challenges/movi/movi_def_worker.py
@@ -50,7 +50,7 @@ parser.add_argument("--floor_restitution", type=float, default=0.5)
 parser.add_argument("--backgrounds_split", choices=["train", "test"],
                     default="train")
 
-parser.add_argument("--camera", choices=["fixed_random", "linear_movement"],
+parser.add_argument("--camera", choices=["fixed_random", "linear_movement", "linear_movement_linear_lookat"],
                     default="fixed_random")
 parser.add_argument("--max_camera_movement", type=float, default=4.0)
 parser.add_argument("--max_motion_blur", type=float, default=0.0)
@@ -169,11 +169,11 @@ if FLAGS.camera == "fixed_random":
       inner_radius=7., outer_radius=9., offset=0.1)
   scene.camera.look_at((0, 0, 0))
 elif (
-    config.camera == "linear_movement"
-    or config.camera == "linear_movement_linear_lookat"
+    FLAGS.camera == "linear_movement"
+    or FLAGS.camera == "linear_movement_linear_lookat"
 ):
 
-  is_panning = config.camera == "linear_movement_linear_lookat"
+  is_panning = FLAGS.camera == "linear_movement_linear_lookat"
   camera_inner_radius = 6.0 if is_panning else 8.0
   camera_start, camera_end = get_linear_camera_motion_start_end(
       movement_speed=rng.uniform(low=0., high=FLAGS.max_camera_movement)


### PR DESCRIPTION
Bug-fix to make the [scene generation](https://github.com/google-research/kubric/tree/e140e24e078d5e641c4ac10bf25743059bd059ce/challenges/movi#movi-e) for Movi-D, Movi-E, and Movi-F work. Running the associated  `docker run -rm interactive ...` commands in the instructions to generate the individual scenes now works. Bug introduced in https://github.com/google-research/kubric/pull/300.