### PR TITLE
Adds an option for GLBs to apply all transforms after import

### DIFF
--- a/kubric/core/objects.py
+++ b/kubric/core/objects.py
@@ -279,4 +279,9 @@ class FileBasedObject(PhysicalObject):
   render_filename = tl.Unicode(allow_none=True)
   render_import_kwargs = tl.Dict(key_trait=tl.ObjectName())
 
+  # If true, applies the transform to all loaded nodes after loading the GLB.
+  # This makes loading GLB files reproduce the expected workflow of Blender in
+  # UI, minus a 90 degree X-axis rotation applied after loading.
+  glb_do_transform_apply_after_import = tl.Bool(False)
+
   # TODO: trigger error when changing filenames or asset-id after the fact

--- a/kubric/renderer/blender.py
+++ b/kubric/renderer/blender.py
@@ -418,6 +418,14 @@ class Blender(core.View):
           elif extension in ["glb", "gltf"]:
             bpy.ops.import_scene.gltf(filepath=obj.render_filename,
                                       **obj.render_import_kwargs)
+
+            # Apply all transforms on objects before subselecting the mesh.
+            # This is optional to not break backwards compatibility.
+            if obj.glb_do_transform_apply_after_import:
+              bpy.ops.object.transform_apply(
+                  location=True, rotation=True, scale=True
+              )
+
             # gltf files often contain "Empty" objects as placeholders for camera / lights etc.
             # here we are interested only in the meshes, we filter these out and join all meshes into one.
             mesh = [m for m in bpy.context.selected_objects if m.type == "MESH"]


### PR DESCRIPTION
This is done before the meshed objects are joined, and the non-meshes objects are discarded.

This fixes issues with objects not retaining the standard orientation (e.g. the one seen when loading them on Blender), as the orientation is stored in a parent node, that is discarded during the GLB loading.