### PR TITLE
switch singledispatchmethod to functools' implementation

### DIFF
--- a/kubric/renderer/blender.py
+++ b/kubric/renderer/blender.py
@@ -27,7 +27,7 @@ from kubric.safeimport.bpy import bpy
 
 import numpy as np
 import tensorflow as tf
-from singledispatchmethod import singledispatchmethod
+from functools import singledispatchmethod
 
 import kubric as kb
 from kubric import core

--- a/kubric/simulator/pybullet.py
+++ b/kubric/simulator/pybullet.py
@@ -23,7 +23,7 @@ import tempfile
 from typing import Dict, List, Optional, Tuple, Union
 
 import tensorflow as tf
-from singledispatchmethod import singledispatchmethod
+from functools import singledispatchmethod
 
 from kubric import core
 from kubric.redirect_io import RedirectStream

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ pypng
 pyquaternion
 python-Levenshtein
 scikit-learn
-singledispatchmethod
 tensorflow
 tensorflow-datasets>=4.1.0
 traitlets


### PR DESCRIPTION
This PR removes dependency on deprecated `singledispatchmethod`.