### PR TITLE
add Alpha (transparency) attribute in Blender material.

### DIFF
--- a/kubric/renderer/blender.py
+++ b/kubric/renderer/blender.py
@@ -24,7 +24,6 @@ from typing import Any, Dict, Optional, Sequence, Union
 
 import kubric as kb
 from kubric import core
-from kubric import file_io
 from kubric.core.assets import UndefinedAsset
 from kubric.file_io import PathLike
 from kubric.redirect_io import RedirectStream
@@ -86,7 +85,7 @@ class Blender(core.View):
     self.blender_scene = bpy.context.scene
 
     # the ray-tracing engine is set here because it affects the availability of some features
-    bpy.context.scene.render.engine = "CYCLES"
+    bpy.context.scene.render.engine = "CYCLES" # BLENDER_EEVEE
     self.use_gpu = os.getenv("KUBRIC_USE_GPU", "False").lower() in ("true", "1", "t")
 
     blender_utils.activate_render_passes(normal=True, optical_flow=True, segmentation=True, uv=True)
@@ -621,6 +620,10 @@ class Blender(core.View):
     obj.observe(AttributeSetter(bsdf_node.inputs["Emission"], "default_value"), "emission")
     obj.observe(KeyframeSetter(bsdf_node.inputs["Emission"], "default_value"), "emission",
                 type="keyframe")
+    obj.observe(AttributeSetter(bsdf_node.inputs["Alpha"], "default_value"), "alpha")
+    obj.observe(KeyframeSetter(bsdf_node.inputs["Alpha"], "default_value"), "alpha",
+                type="keyframe")
+    
     return mat
 
   @add_asset.register(core.FlatMaterial)


### PR DESCRIPTION
Add Alpha: controls the transparency of the surface in blender renderer.

- Reference link: https://docs.blender.org/manual/en/latest/render/shader_nodes/shader/principled.html