### PR TITLE
add Alpha(transparency) attribute in Blender renderer

### DIFF
--- a/kubric/renderer/blender.py
+++ b/kubric/renderer/blender.py
@@ -86,7 +86,7 @@ class Blender(core.View):
     self.blender_scene = bpy.context.scene
 
     # the ray-tracing engine is set here because it affects the availability of some features
-    bpy.context.scene.render.engine = "CYCLES"
+    bpy.context.scene.render.engine = "CYCLES" # "BLENDER_EEVEE"
     self.use_gpu = os.getenv("KUBRIC_USE_GPU", "False").lower() in ("true", "1", "t")
 
     blender_utils.activate_render_passes(normal=True, optical_flow=True, segmentation=True, uv=True)
@@ -354,7 +354,7 @@ class Blender(core.View):
         logger.info("Loading scene from '%s'", custom_scene)
         bpy.ops.wm.open_mainfile(filepath=custom_scene)
 
-  @functools.singledispatchmethod
+  @singledispatchmethod
   def add_asset(self, asset: core.Asset) -> Any:
     raise NotImplementedError(f"Cannot add {asset!r}")
 
@@ -621,6 +621,11 @@ class Blender(core.View):
     obj.observe(AttributeSetter(bsdf_node.inputs["Emission"], "default_value"), "emission")
     obj.observe(KeyframeSetter(bsdf_node.inputs["Emission"], "default_value"), "emission",
                 type="keyframe")
+    obj.observe(AttributeSetter(bsdf_node.inputs["Alpha"], "default_value"), "alpha")
+    obj.observe(KeyframeSetter(bsdf_node.inputs["Alpha"], "default_value"), "alpha",
+                type="keyframe")
+    
+
     return mat
 
   @add_asset.register(core.FlatMaterial)


### PR DESCRIPTION
- Add Alpha parameter: Controls the transparency of the surface, with 1.0 fully opaque. Usually linked to the Alpha output of an Image Texture node.

- Reference Link: https://docs.blender.org/manual/en/latest/render/shader_nodes/shader/principled.html