### PR TITLE
Fix kubric data loading of video shape (None, 256, 256, None)

### DIFF
--- a/challenges/point_tracking/dataset.py
+++ b/challenges/point_tracking/dataset.py
@@ -929,6 +929,7 @@ def add_tracks(data,
   )
   video = tf.slice(video, start, size)
   video = tf.image.resize(tf.cast(video, tf.float32), train_size)
+  video.set_shape([num_frames, train_size[0], train_size[1], 3])
   if vflip:
     video = video[:, ::-1, :, :]
     target_points = target_points * np.array([1, -1])


### PR DESCRIPTION
video = tf.slice(video, start, size) will return shape (None, None, None, None).
video = tf.image.resize(tf.cast(video, tf.float32), train_size) will return shape (None, 256, 256, None).

Unfortunately Kauldron does not accept None in the shape specification.

Adding set_shape should fix it.